### PR TITLE
notifications_win: pass MAKEINTRESOURCEW to LoadImageW

### DIFF
--- a/backend-common/src/notifications_win.cc
+++ b/backend-common/src/notifications_win.cc
@@ -153,7 +153,7 @@ done:
 }
 
 HICON LoadDefaultAppIcon() {
-  return (HICON)LoadImageW(GetModuleHandleW(nullptr), IDI_APPLICATION,
+  return (HICON)LoadImageW(GetModuleHandleW(nullptr), MAKEINTRESOURCEW(32512),
                            IMAGE_ICON, 0, 0, LR_SHARED | LR_DEFAULTSIZE);
 }
 


### PR DESCRIPTION
`IDI_APPLICATION` expands to the ANSI `MAKEINTRESOURCEA` macro, but it was being passed to the wide `LoadImageW`, which misinterprets the pointer. Use `MAKEINTRESOURCEW(32512)` so the default application icon loads.

Found while building `deno desktop` (WEF API 24) on Windows 11.