### PR TITLE
refactor(webview): share injected JS bridge across platforms

### DIFF
--- a/webview/src/init_script.h
+++ b/webview/src/init_script.h
@@ -8,7 +8,38 @@
 #ifndef WEF_WEBVIEW_INIT_SCRIPT_H_
 #define WEF_WEBVIEW_INIT_SCRIPT_H_
 
+#include <cstdint>
 #include <string>
+
+// The host->page side of the bridge protocol. These build the JS statements
+// that call the functions defined by BuildInitScript() below, so the function
+// names live in exactly one place. Each platform backend builds the statement
+// and hands it to its own evaluate-JavaScript call.
+
+// window.__wefRespond(callId, result, error): resolve/reject a pending call.
+inline std::string BuildRespondScript(uint64_t call_id,
+                                      const std::string& result_json,
+                                      const std::string& error_json,
+                                      bool is_error) {
+  if (is_error) {
+    return "window.__wefRespond(" + std::to_string(call_id) + ", null, " +
+           error_json + ");";
+  }
+  return "window.__wefRespond(" + std::to_string(call_id) + ", " + result_json +
+         ", null);";
+}
+
+// window.__wefInvokeCallback(callbackId, args): call a stored JS callback.
+inline std::string BuildInvokeCallbackScript(uint64_t callback_id,
+                                             const std::string& args_json) {
+  return "window.__wefInvokeCallback(" + std::to_string(callback_id) + ", " +
+         args_json + ");";
+}
+
+// window.__wefReleaseCallback(callbackId): drop a stored JS callback.
+inline std::string BuildReleaseCallbackScript(uint64_t callback_id) {
+  return "window.__wefReleaseCallback(" + std::to_string(callback_id) + ");";
+}
 
 // Builds the page init script. `ns` is the global namespace the proxy is
 // installed under (e.g. "wef"); `postMessage` is the platform-specific

--- a/webview/src/init_script.h
+++ b/webview/src/init_script.h
@@ -1,0 +1,118 @@
+// Copyright 2025 Divy Srivastava. All rights reserved. MIT license.
+
+// The JavaScript bridge injected into every page is identical across all
+// platform webview backends; only the host-specific postMessage expression and
+// the namespace differ. Keep one copy here instead of duplicating it in
+// webview_macos.mm / webview_linux.cc / webview_windows.cc.
+
+#ifndef WEF_WEBVIEW_INIT_SCRIPT_H_
+#define WEF_WEBVIEW_INIT_SCRIPT_H_
+
+#include <string>
+
+// Builds the page init script. `ns` is the global namespace the proxy is
+// installed under (e.g. "wef"); `postMessage` is the platform-specific
+// statement that ships the {callId, path, args} message to the host.
+inline std::string BuildInitScript(const std::string& ns,
+                                   const std::string& postMessage) {
+  return R"JS(
+(function() {
+  const pendingCalls = new Map();
+  let nextCallId = 1;
+
+  function createWefProxy(path = []) {
+    return new Proxy(function() {}, {
+      get(target, prop) {
+        if (prop === 'then' || prop === 'catch' || prop === 'finally' ||
+            prop === 'constructor' || prop === Symbol.toStringTag) {
+          return undefined;
+        }
+        return createWefProxy([...path, prop]);
+      },
+      apply(target, thisArg, args) {
+        return new Promise((resolve, reject) => {
+          const callId = nextCallId++;
+          pendingCalls.set(callId, { resolve, reject });
+
+          const processedArgs = args.map(arg => {
+            if (typeof arg === 'function') {
+              const cbId = nextCallId++;
+              window.__wefCallbacks = window.__wefCallbacks || {};
+              window.__wefCallbacks[cbId] = arg;
+              return { __callback__: String(cbId) };
+            }
+            if (arg instanceof ArrayBuffer) {
+              const bytes = new Uint8Array(arg);
+              let binary = '';
+              bytes.forEach(b => binary += String.fromCharCode(b));
+              return { __binary__: btoa(binary) };
+            }
+            if (arg instanceof Uint8Array) {
+              let binary = '';
+              arg.forEach(b => binary += String.fromCharCode(b));
+              return { __binary__: btoa(binary) };
+            }
+            return arg;
+          });
+
+          )JS" +
+         postMessage + R"JS(
+        });
+      }
+    });
+  }
+
+  window[")JS" +
+         ns + R"JS("] = createWefProxy();
+
+  window.__wefRespond = function(callId, result, error) {
+    const pending = pendingCalls.get(callId);
+    if (pending) {
+      pendingCalls.delete(callId);
+      if (error) {
+        pending.reject(new Error(error));
+      } else {
+        function convertBinary(obj) {
+          if (obj && typeof obj === 'object') {
+            if (obj.__binary__) {
+              const binary = atob(obj.__binary__);
+              const bytes = new Uint8Array(binary.length);
+              for (let i = 0; i < binary.length; i++) {
+                bytes[i] = binary.charCodeAt(i);
+              }
+              return bytes.buffer;
+            }
+            if (Array.isArray(obj)) {
+              return obj.map(convertBinary);
+            }
+            const result = {};
+            for (const key in obj) {
+              result[key] = convertBinary(obj[key]);
+            }
+            return result;
+          }
+          return obj;
+        }
+        pending.resolve(convertBinary(result));
+      }
+    }
+  };
+
+  window.__wefInvokeCallback = function(callbackId, args) {
+    const cb = window.__wefCallbacks && window.__wefCallbacks[callbackId];
+    if (cb) {
+      cb.apply(null, args);
+    }
+  };
+
+  window.__wefReleaseCallback = function(callbackId) {
+    if (window.__wefCallbacks) {
+      delete window.__wefCallbacks[callbackId];
+    }
+  };
+
+})();
+)JS";
+}
+
+#endif  // WEF_WEBVIEW_INIT_SCRIPT_H_

--- a/webview/src/webview_linux.cc
+++ b/webview/src/webview_linux.cc
@@ -870,8 +870,7 @@ void WebKitGTKBackend::InvokeJsCallback(uint32_t window_id,
                                         uint64_t callback_id,
                                         wef::ValuePtr args) {
   std::string argsJson = json::Serialize(args);
-  std::string script = "window.__wefInvokeCallback(" +
-                       std::to_string(callback_id) + ", " + argsJson + ");";
+  std::string script = BuildInvokeCallbackScript(callback_id, argsJson);
   std::lock_guard<std::mutex> lock(windows_mutex_);
   if (window_id == 0) {
     for (auto& [wid, state] : windows_) {
@@ -889,8 +888,7 @@ void WebKitGTKBackend::InvokeJsCallback(uint32_t window_id,
 
 void WebKitGTKBackend::ReleaseJsCallback(uint32_t window_id,
                                          uint64_t callback_id) {
-  std::string script =
-      "window.__wefReleaseCallback(" + std::to_string(callback_id) + ");";
+  std::string script = BuildReleaseCallbackScript(callback_id);
   std::lock_guard<std::mutex> lock(windows_mutex_);
   if (window_id == 0) {
     for (auto& [wid, state] : windows_) {
@@ -912,14 +910,8 @@ void WebKitGTKBackend::RespondToJsCall(uint32_t window_id, uint64_t call_id,
   std::string resultJson = json::Serialize(result);
   std::string errorJson =
       (error && !error->IsNull()) ? json::Serialize(error) : "null";
-  std::string script;
-  if (errorJson == "null") {
-    script = "window.__wefRespond(" + std::to_string(call_id) + ", " +
-             resultJson + ", null);";
-  } else {
-    script = "window.__wefRespond(" + std::to_string(call_id) + ", null, " +
-             errorJson + ");";
-  }
+  std::string script =
+      BuildRespondScript(call_id, resultJson, errorJson, errorJson != "null");
   std::lock_guard<std::mutex> lock(windows_mutex_);
   auto* state = GetWindow(window_id);
   if (state) {

--- a/webview/src/webview_linux.cc
+++ b/webview/src/webview_linux.cc
@@ -6,6 +6,7 @@
 #include "runtime_loader.h"
 #include "wef_backend_common.h"
 #include "wef_json.h"
+#include "init_script.h"
 #include <webkit2/webkit2.h>
 #include <JavaScriptCore/JavaScript.h>
 
@@ -391,108 +392,6 @@ static WebKitGTKBackend* g_gtk_backend = nullptr;
 // GtkWidget → window_id mapping for script message routing
 static std::map<WebKitUserContentManager*, uint32_t>
     g_content_manager_to_wef_id;
-
-static std::string BuildInitScript(const std::string& ns,
-                                   const std::string& postMessage) {
-  return R"JS(
-(function() {
-  const pendingCalls = new Map();
-  let nextCallId = 1;
-
-  function createWefProxy(path = []) {
-    return new Proxy(function() {}, {
-      get(target, prop) {
-        if (prop === 'then' || prop === 'catch' || prop === 'finally' ||
-            prop === 'constructor' || prop === Symbol.toStringTag) {
-          return undefined;
-        }
-        return createWefProxy([...path, prop]);
-      },
-      apply(target, thisArg, args) {
-        return new Promise((resolve, reject) => {
-          const callId = nextCallId++;
-          pendingCalls.set(callId, { resolve, reject });
-
-          const processedArgs = args.map(arg => {
-            if (typeof arg === 'function') {
-              const cbId = nextCallId++;
-              window.__wefCallbacks = window.__wefCallbacks || {};
-              window.__wefCallbacks[cbId] = arg;
-              return { __callback__: String(cbId) };
-            }
-            if (arg instanceof ArrayBuffer) {
-              const bytes = new Uint8Array(arg);
-              let binary = '';
-              bytes.forEach(b => binary += String.fromCharCode(b));
-              return { __binary__: btoa(binary) };
-            }
-            if (arg instanceof Uint8Array) {
-              let binary = '';
-              arg.forEach(b => binary += String.fromCharCode(b));
-              return { __binary__: btoa(binary) };
-            }
-            return arg;
-          });
-
-          )JS" +
-         postMessage + R"JS(
-        });
-      }
-    });
-  }
-
-  window[")JS" +
-         ns + R"JS("] = createWefProxy();
-
-  window.__wefRespond = function(callId, result, error) {
-    const pending = pendingCalls.get(callId);
-    if (pending) {
-      pendingCalls.delete(callId);
-      if (error) {
-        pending.reject(new Error(error));
-      } else {
-        function convertBinary(obj) {
-          if (obj && typeof obj === 'object') {
-            if (obj.__binary__) {
-              const binary = atob(obj.__binary__);
-              const bytes = new Uint8Array(binary.length);
-              for (let i = 0; i < binary.length; i++) {
-                bytes[i] = binary.charCodeAt(i);
-              }
-              return bytes.buffer;
-            }
-            if (Array.isArray(obj)) {
-              return obj.map(convertBinary);
-            }
-            const result = {};
-            for (const key in obj) {
-              result[key] = convertBinary(obj[key]);
-            }
-            return result;
-          }
-          return obj;
-        }
-        pending.resolve(convertBinary(result));
-      }
-    }
-  };
-
-  window.__wefInvokeCallback = function(callbackId, args) {
-    const cb = window.__wefCallbacks && window.__wefCallbacks[callbackId];
-    if (cb) {
-      cb.apply(null, args);
-    }
-  };
-
-  window.__wefReleaseCallback = function(callbackId) {
-    if (window.__wefCallbacks) {
-      delete window.__wefCallbacks[callbackId];
-    }
-  };
-
-})();
-)JS";
-}
 
 static void on_script_message(WebKitUserContentManager* manager,
                               WebKitJavascriptResult* js_result,

--- a/webview/src/webview_macos.mm
+++ b/webview/src/webview_macos.mm
@@ -1063,24 +1063,20 @@ void WKWebViewBackend::InvokeJsCallback(uint32_t window_id,
                                         uint64_t callback_id,
                                         wef::ValuePtr args) {
   std::string argsJson = json::Serialize(args);
+  std::string script = BuildInvokeCallbackScript(callback_id, argsJson);
   dispatch_async(dispatch_get_main_queue(), ^{
     @autoreleasepool {
       std::lock_guard<std::mutex> lock(windows_mutex_);
+      NSString* js = [NSString stringWithUTF8String:script.c_str()];
       // window_id == 0 means broadcast to all windows
       if (window_id == 0) {
         for (auto& [wid, state] : windows_) {
-          NSString* script = [NSString
-              stringWithFormat:@"window.__wefInvokeCallback(%llu, %s);",
-                               callback_id, argsJson.c_str()];
-          [state.webview evaluateJavaScript:script completionHandler:nil];
+          [state.webview evaluateJavaScript:js completionHandler:nil];
         }
       } else {
         auto* state = GetWindow(window_id);
         if (state) {
-          NSString* script = [NSString
-              stringWithFormat:@"window.__wefInvokeCallback(%llu, %s);",
-                               callback_id, argsJson.c_str()];
-          [state->webview evaluateJavaScript:script completionHandler:nil];
+          [state->webview evaluateJavaScript:js completionHandler:nil];
         }
       }
     }
@@ -1089,23 +1085,19 @@ void WKWebViewBackend::InvokeJsCallback(uint32_t window_id,
 
 void WKWebViewBackend::ReleaseJsCallback(uint32_t window_id,
                                          uint64_t callback_id) {
+  std::string script = BuildReleaseCallbackScript(callback_id);
   dispatch_async(dispatch_get_main_queue(), ^{
     @autoreleasepool {
       std::lock_guard<std::mutex> lock(windows_mutex_);
+      NSString* js = [NSString stringWithUTF8String:script.c_str()];
       if (window_id == 0) {
         for (auto& [wid, state] : windows_) {
-          NSString* script =
-              [NSString stringWithFormat:@"window.__wefReleaseCallback(%llu);",
-                                         callback_id];
-          [state.webview evaluateJavaScript:script completionHandler:nil];
+          [state.webview evaluateJavaScript:js completionHandler:nil];
         }
       } else {
         auto* state = GetWindow(window_id);
         if (state) {
-          NSString* script =
-              [NSString stringWithFormat:@"window.__wefReleaseCallback(%llu);",
-                                         callback_id];
-          [state->webview evaluateJavaScript:script completionHandler:nil];
+          [state->webview evaluateJavaScript:js completionHandler:nil];
         }
       }
     }
@@ -1117,24 +1109,16 @@ void WKWebViewBackend::RespondToJsCall(uint32_t window_id, uint64_t call_id,
                                        wef::ValuePtr error) {
   std::string resultJson = json::Serialize(result);
   std::string errorJson = error ? json::Serialize(error) : "null";
+  std::string script = BuildRespondScript(call_id, resultJson, errorJson,
+                                          static_cast<bool>(error));
   dispatch_async(dispatch_get_main_queue(), ^{
     @autoreleasepool {
       std::lock_guard<std::mutex> lock(windows_mutex_);
       auto* state = GetWindow(window_id);
       if (!state)
         return;
-
-      NSString* script;
-      if (error) {
-        script =
-            [NSString stringWithFormat:@"window.__wefRespond(%llu, null, %s);",
-                                       call_id, errorJson.c_str()];
-      } else {
-        script =
-            [NSString stringWithFormat:@"window.__wefRespond(%llu, %s, null);",
-                                       call_id, resultJson.c_str()];
-      }
-      [state->webview evaluateJavaScript:script completionHandler:nil];
+      NSString* js = [NSString stringWithUTF8String:script.c_str()];
+      [state->webview evaluateJavaScript:js completionHandler:nil];
     }
   });
 }

--- a/webview/src/webview_macos.mm
+++ b/webview/src/webview_macos.mm
@@ -7,6 +7,7 @@
 #include "runtime_loader.h"
 #include "wef_backend_common.h"
 #include "wef_json.h"
+#include "init_script.h"
 
 #include <atomic>
 #include <map>
@@ -323,108 +324,6 @@ int NSButtonToWef(NSInteger buttonNumber) {
     default:
       return WEF_MOUSE_BUTTON_LEFT;
   }
-}
-
-std::string BuildInitScript(const std::string& ns,
-                            const std::string& postMessage) {
-  return R"JS(
-(function() {
-  const pendingCalls = new Map();
-  let nextCallId = 1;
-
-  function createWefProxy(path = []) {
-    return new Proxy(function() {}, {
-      get(target, prop) {
-        if (prop === 'then' || prop === 'catch' || prop === 'finally' ||
-            prop === 'constructor' || prop === Symbol.toStringTag) {
-          return undefined;
-        }
-        return createWefProxy([...path, prop]);
-      },
-      apply(target, thisArg, args) {
-        return new Promise((resolve, reject) => {
-          const callId = nextCallId++;
-          pendingCalls.set(callId, { resolve, reject });
-
-          const processedArgs = args.map(arg => {
-            if (typeof arg === 'function') {
-              const cbId = nextCallId++;
-              window.__wefCallbacks = window.__wefCallbacks || {};
-              window.__wefCallbacks[cbId] = arg;
-              return { __callback__: String(cbId) };
-            }
-            if (arg instanceof ArrayBuffer) {
-              const bytes = new Uint8Array(arg);
-              let binary = '';
-              bytes.forEach(b => binary += String.fromCharCode(b));
-              return { __binary__: btoa(binary) };
-            }
-            if (arg instanceof Uint8Array) {
-              let binary = '';
-              arg.forEach(b => binary += String.fromCharCode(b));
-              return { __binary__: btoa(binary) };
-            }
-            return arg;
-          });
-
-          )JS" +
-         postMessage + R"JS(
-        });
-      }
-    });
-  }
-
-  window[")JS" +
-         ns + R"JS("] = createWefProxy();
-
-  window.__wefRespond = function(callId, result, error) {
-    const pending = pendingCalls.get(callId);
-    if (pending) {
-      pendingCalls.delete(callId);
-      if (error) {
-        pending.reject(new Error(error));
-      } else {
-        function convertBinary(obj) {
-          if (obj && typeof obj === 'object') {
-            if (obj.__binary__) {
-              const binary = atob(obj.__binary__);
-              const bytes = new Uint8Array(binary.length);
-              for (let i = 0; i < binary.length; i++) {
-                bytes[i] = binary.charCodeAt(i);
-              }
-              return bytes.buffer;
-            }
-            if (Array.isArray(obj)) {
-              return obj.map(convertBinary);
-            }
-            const result = {};
-            for (const key in obj) {
-              result[key] = convertBinary(obj[key]);
-            }
-            return result;
-          }
-          return obj;
-        }
-        pending.resolve(convertBinary(result));
-      }
-    }
-  };
-
-  window.__wefInvokeCallback = function(callbackId, args) {
-    const cb = window.__wefCallbacks && window.__wefCallbacks[callbackId];
-    if (cb) {
-      cb.apply(null, args);
-    }
-  };
-
-  window.__wefReleaseCallback = function(callbackId) {
-    if (window.__wefCallbacks) {
-      delete window.__wefCallbacks[callbackId];
-    }
-  };
-
-})();
-)JS";
 }
 
 }  // namespace

--- a/webview/src/webview_windows.cc
+++ b/webview/src/webview_windows.cc
@@ -799,9 +799,8 @@ void WebView2Backend::PostUiTask(void (*task)(void*), void* data) {
 void WebView2Backend::InvokeJsCallback(uint32_t window_id, uint64_t callback_id,
                                        wef::ValuePtr args) {
   std::string argsJson = json::Serialize(args);
-  std::string script = "window.__wefInvokeCallback(" +
-                       std::to_string(callback_id) + ", " + argsJson + ");";
-  std::wstring wscript = Utf8ToWide(script);
+  std::wstring wscript =
+      Utf8ToWide(BuildInvokeCallbackScript(callback_id, argsJson));
   std::lock_guard<std::mutex> lock(windows_mutex_);
   if (window_id == 0) {
     for (auto& [wid, state] : windows_) {
@@ -819,9 +818,7 @@ void WebView2Backend::InvokeJsCallback(uint32_t window_id, uint64_t callback_id,
 
 void WebView2Backend::ReleaseJsCallback(uint32_t window_id,
                                         uint64_t callback_id) {
-  std::string script =
-      "window.__wefReleaseCallback(" + std::to_string(callback_id) + ");";
-  std::wstring wscript = Utf8ToWide(script);
+  std::wstring wscript = Utf8ToWide(BuildReleaseCallbackScript(callback_id));
   std::lock_guard<std::mutex> lock(windows_mutex_);
   if (window_id == 0) {
     for (auto& [wid, state] : windows_) {
@@ -841,16 +838,9 @@ void WebView2Backend::RespondToJsCall(uint32_t window_id, uint64_t call_id,
                                       wef::ValuePtr result,
                                       wef::ValuePtr error) {
   std::string resultJson = json::Serialize(result);
-  std::string script;
-  if (error) {
-    std::string errorJson = json::Serialize(error);
-    script = "window.__wefRespond(" + std::to_string(call_id) + ", null, " +
-             errorJson + ");";
-  } else {
-    script = "window.__wefRespond(" + std::to_string(call_id) + ", " +
-             resultJson + ", null);";
-  }
-  std::wstring wscript = Utf8ToWide(script);
+  std::string errorJson = error ? json::Serialize(error) : "null";
+  std::wstring wscript = Utf8ToWide(BuildRespondScript(
+      call_id, resultJson, errorJson, static_cast<bool>(error)));
   std::lock_guard<std::mutex> lock(windows_mutex_);
   auto* state = GetWindow(window_id);
   if (state && state->webview_ready && state->webview) {

--- a/webview/src/webview_windows.cc
+++ b/webview/src/webview_windows.cc
@@ -3,6 +3,7 @@
 #include "runtime_loader.h"
 #include "wef_backend_common.h"
 #include "wef_json.h"
+#include "init_script.h"
 #include <win32_menu.h>
 
 #define WIN32_LEAN_AND_MEAN
@@ -117,108 +118,6 @@ struct UiTaskData {
 // ============================================================================
 // WebView2 Backend
 // ============================================================================
-
-static std::string BuildInitScript(const std::string& ns,
-                                   const std::string& postMessage) {
-  return R"JS(
-(function() {
-  const pendingCalls = new Map();
-  let nextCallId = 1;
-
-  function createWefProxy(path = []) {
-    return new Proxy(function() {}, {
-      get(target, prop) {
-        if (prop === 'then' || prop === 'catch' || prop === 'finally' ||
-            prop === 'constructor' || prop === Symbol.toStringTag) {
-          return undefined;
-        }
-        return createWefProxy([...path, prop]);
-      },
-      apply(target, thisArg, args) {
-        return new Promise((resolve, reject) => {
-          const callId = nextCallId++;
-          pendingCalls.set(callId, { resolve, reject });
-
-          const processedArgs = args.map(arg => {
-            if (typeof arg === 'function') {
-              const cbId = nextCallId++;
-              window.__wefCallbacks = window.__wefCallbacks || {};
-              window.__wefCallbacks[cbId] = arg;
-              return { __callback__: String(cbId) };
-            }
-            if (arg instanceof ArrayBuffer) {
-              const bytes = new Uint8Array(arg);
-              let binary = '';
-              bytes.forEach(b => binary += String.fromCharCode(b));
-              return { __binary__: btoa(binary) };
-            }
-            if (arg instanceof Uint8Array) {
-              let binary = '';
-              arg.forEach(b => binary += String.fromCharCode(b));
-              return { __binary__: btoa(binary) };
-            }
-            return arg;
-          });
-
-          )JS" +
-         postMessage + R"JS(
-        });
-      }
-    });
-  }
-
-  window[")JS" +
-         ns + R"JS("] = createWefProxy();
-
-  window.__wefRespond = function(callId, result, error) {
-    const pending = pendingCalls.get(callId);
-    if (pending) {
-      pendingCalls.delete(callId);
-      if (error) {
-        pending.reject(new Error(error));
-      } else {
-        function convertBinary(obj) {
-          if (obj && typeof obj === 'object') {
-            if (obj.__binary__) {
-              const binary = atob(obj.__binary__);
-              const bytes = new Uint8Array(binary.length);
-              for (let i = 0; i < binary.length; i++) {
-                bytes[i] = binary.charCodeAt(i);
-              }
-              return bytes.buffer;
-            }
-            if (Array.isArray(obj)) {
-              return obj.map(convertBinary);
-            }
-            const result = {};
-            for (const key in obj) {
-              result[key] = convertBinary(obj[key]);
-            }
-            return result;
-          }
-          return obj;
-        }
-        pending.resolve(convertBinary(result));
-      }
-    }
-  };
-
-  window.__wefInvokeCallback = function(callbackId, args) {
-    const cb = window.__wefCallbacks && window.__wefCallbacks[callbackId];
-    if (cb) {
-      cb.apply(null, args);
-    }
-  };
-
-  window.__wefReleaseCallback = function(callbackId) {
-    if (window.__wefCallbacks) {
-      delete window.__wefCallbacks[callbackId];
-    }
-  };
-
-})();
-)JS";
-}
 
 class WebView2Backend;
 static WebView2Backend* g_win_backend = nullptr;


### PR DESCRIPTION
`BuildInitScript` (the ~100-line JS proxy/bridge injected into every page) was **byte-identical** across `webview_macos.mm`, `webview_linux.cc`, and `webview_windows.cc`. Extracted to `webview/src/init_script.h`; each platform file includes it and passes only its host-specific `postMessage` expression.

Removes ~200 lines of duplication. macOS built locally; linux/windows via CI.