### PR TITLE
fix(webview): resolve bindings to actual values instead of null

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,6 +353,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "binding_test"
+version = "0.1.0"
+dependencies = [
+ "laufey",
+ "tokio",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "winit",
     "backend-winit-common",
     "examples/hello",
+    "examples/binding_test",
     "examples/ddcore",
     "examples/presentation",
     "examples/cef_e2e",

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ laufey::main!(main);
 ### Docs
 
 - [architecture.md](docs/architecture.md) — backend/runtime split
-- [c-abi.md](docs/c-abi.md) — the `laufey.h` C ABI: runtime entry points, the API
-  table, the value model, and the JS call flow
+- [c-abi.md](docs/c-abi.md) — the `laufey.h` C ABI: runtime entry points, the
+  API table, the value model, and the JS call flow
 - [backends.md](docs/backends.md) — CEF, WebView, and Winit
 - [features/](docs/features/) — one page per feature, with a usage example and
   the per-platform support matrix

--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -134,6 +134,7 @@ pub fn should_shutdown() -> bool {
   SHUTDOWN_FLAG.load(Ordering::SeqCst)
 }
 
+#[derive(Clone)]
 pub enum Value {
   Null,
   Bool(bool),

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,11 +36,11 @@ function pointers from `laufey_backend_api_t` into safe Rust types (`Window`,
 
 ### The C ABI contract (`laufey_backend_api_t`)
 
-The central interface is a struct of function pointers (`capi/include/laufey.h`).
-The backend fills this struct and passes a pointer to `laufey_runtime_init()`. The
-runtime stores it for the process lifetime. Every capability (navigation, JS
-execution, event handlers, window management) is a nullable function pointer in
-this struct.
+The central interface is a struct of function pointers
+(`capi/include/laufey.h`). The backend fills this struct and passes a pointer to
+`laufey_runtime_init()`. The runtime stores it for the process lifetime. Every
+capability (navigation, JS execution, event handlers, window management) is a
+nullable function pointer in this struct.
 
 **Adding a new API**: add the field to `laufey_backend_api_t` in
 `capi/include/laufey.h`, then implement it in every backend. Both C++ backends
@@ -51,7 +51,8 @@ CMake variable — there is no second copy to sync.
 
 All event handlers follow the same pattern:
 
-1. Define a C callback type (`laufey_keyboard_event_fn`, `laufey_mouse_click_fn`)
+1. Define a C callback type (`laufey_keyboard_event_fn`,
+   `laufey_mouse_click_fn`)
 2. Add a `set_*_handler(backend_data, callback, user_data)` function pointer to
    the API struct
 3. Backend stores the callback+user_data behind a mutex
@@ -71,9 +72,10 @@ duplicate. Each backend `add_subdirectory`s it and links `laufey_backend_common`
 from its platform branch.
 
 The bridge is intentionally minimal — common code never touches the
-backend-specific `laufey_value_t` types. Each backend pre-parses `laufey_value_t` into
-plain C++ structs (`laufey_common::NotificationOptions`, etc.) before calling into
-common functions. Header: `backend-common/include/laufey_backend_common.h`.
+backend-specific `laufey_value_t` types. Each backend pre-parses
+`laufey_value_t` into plain C++ structs (`laufey_common::NotificationOptions`,
+etc.) before calling into common functions. Header:
+`backend-common/include/laufey_backend_common.h`.
 
 Currently shared:
 
@@ -86,7 +88,7 @@ Currently shared:
 | **Key mapping**                    | `keymap_mac.mm` (NSEvent → W3C)                                                                                  | `keymap_vk.cc` (VK → W3C; CEF uses on every platform)          | `keymap_gdk.cc` (GDK → W3C)                                                |
 | **App / context menu**             | `menu_mac.mm` (NSMenu)                                                                                           | `capi/include/win32_menu.h` (HMENU + SetMenu / TrackPopupMenu) | `menu_linux.cc` (GtkMenu / GtkMenuBar)                                     |
 | **Tray icons**                     | `tray_mac.mm` (NSStatusItem)                                                                                     | `tray_win.cc` (Shell_NotifyIcon + WIC + HMENU)                 | `tray_linux.cc` (libappindicator + g_idle_add)                             |
-| **Option parsing**                 | `parse_options.cc` (compiled on every platform; bridges `laufey_value_t` → plain structs)                           |                                                                |                                                                            |
+| **Option parsing**                 | `parse_options.cc` (compiled on every platform; bridges `laufey_value_t` → plain structs)                        |                                                                |                                                                            |
 | **Title-prefix badge bookkeeping** | `title_badge.cc` (`ApplyTitlePrefixBadge` — used by CEF Win+Linux and webview Win+Linux for Dock-badge fallback) |                                                                |                                                                            |
 
 Notes:
@@ -206,8 +208,8 @@ Platform-specific mappings:
 
 ### Value marshalling
 
-The laufey API has a rich value type (`laufey_value_t`) for JS interop. Backends own
-the value representation:
+The laufey API has a rich value type (`laufey_value_t`) for JS interop. Backends
+own the value representation:
 
 - **CEF**: wraps `CefValue` / `CefListValue` directly
 - **Webview**: uses a custom `Value` class with JSON serialization for JS

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -1,14 +1,14 @@
 # Backends
 
 A backend is the native executable that hosts a browser (or windowing) engine
-and implements the [C ABI](c-abi.md). laufey ships three; a fourth is on a branch.
-All implement the same `laufey_backend_api_t`, so a runtime is portable across them
-— the differences are in engine, process model, size, and a few features that a
-given engine can't express on a given OS (see
+and implements the [C ABI](c-abi.md). laufey ships three; a fourth is on a
+branch. All implement the same `laufey_backend_api_t`, so a runtime is portable
+across them — the differences are in engine, process model, size, and a few
+features that a given engine can't express on a given OS (see
 [the feature pages](window-management.md)).
 
-| Backend                                                             | Engine        | Process model | Bundled | JS bridge |
-| ------------------------------------------------------------------- | ------------- | ------------- | ------- | --------- |
+| Backend                                                           | Engine        | Process model | Bundled | JS bridge |
+| ----------------------------------------------------------------- | ------------- | ------------- | ------- | --------- |
 | [CEF](https://github.com/littledivy/laufey/tree/main/cef)         | Chromium 144  | multi-process | yes     | yes       |
 | [WebView](https://github.com/littledivy/laufey/tree/main/webview) | system native | single        | no      | yes       |
 | [Winit](https://github.com/littledivy/laufey/tree/main/winit)     | none          | single        | n/a     | no        |
@@ -58,8 +58,8 @@ handles needed to create a rendering surface. Sources in
 ## Servo (experimental)
 
 A [Servo](https://servo.org)-based backend is preserved on the
-[`servo`](https://github.com/littledivy/laufey/tree/servo) branch for future work
-and is not part of the mainline build.
+[`servo`](https://github.com/littledivy/laufey/tree/servo) branch for future
+work and is not part of the mainline build.
 
 ## backend-common
 

--- a/docs/c-abi.md
+++ b/docs/c-abi.md
@@ -6,19 +6,19 @@ It defines the boundary between a **backend** (a native executable embedding a
 browser engine) and a **runtime** (a shared library holding the application
 logic). The backend implements the ABI; the runtime consumes it.
 
-`LAUFEY_API_VERSION` (currently `25`) versions the contract. The `version` field on
-the API table lets a runtime detect the backend's vintage and avoid calling
+`LAUFEY_API_VERSION` (currently `25`) versions the contract. The `version` field
+on the API table lets a runtime detect the backend's vintage and avoid calling
 function pointers a backend predates (older backends leave new pointers `NULL`).
 
 ## Runtime entry points
 
 A runtime is a `.dylib`/`.so`/`.dll` that exports three symbols:
 
-| Symbol (`*_SYMBOL` macro) | Signature                           | Role                                                                           |
-| ------------------------- | ----------------------------------- | ------------------------------------------------------------------------------ |
-| `laufey_runtime_init`        | `int(const laufey_backend_api_t* api)` | Backend hands the runtime the API table. Stash it; return 0 on success.        |
-| `laufey_runtime_start`       | `int(void)`                         | Run application setup (create windows, register handlers). Returns when ready. |
-| `laufey_runtime_shutdown`    | `void(void)`                        | Tear down before the process exits.                                            |
+| Symbol (`*_SYMBOL` macro) | Signature                              | Role                                                                           |
+| ------------------------- | -------------------------------------- | ------------------------------------------------------------------------------ |
+| `laufey_runtime_init`     | `int(const laufey_backend_api_t* api)` | Backend hands the runtime the API table. Stash it; return 0 on success.        |
+| `laufey_runtime_start`    | `int(void)`                            | Run application setup (create windows, register handlers). Returns when ready. |
+| `laufey_runtime_shutdown` | `void(void)`                           | Tear down before the process exits.                                            |
 
 The backend `dlopen`s the runtime, resolves these symbols, calls `init` then
 `start`, and drives the OS event loop. Control flows backend → runtime through
@@ -43,8 +43,8 @@ hand-rolled vtable with no global state. Windows are referenced by an opaque
 The pointers group into:
 
 - **Window lifecycle** — `create_window`, `create_window_ex` (style flags, see
-  `LAUFEY_WINDOW_FLAG_*`), `close_window`, `navigate`, `set_title`, size/position
-  get+set, `set_resizable`/`is_resizable`,
+  `LAUFEY_WINDOW_FLAG_*`), `close_window`, `navigate`, `set_title`,
+  size/position get+set, `set_resizable`/`is_resizable`,
   `set_always_on_top`/`is_always_on_top`, `show`/`hide`/`is_visible`, `focus`,
   `quit`, `post_ui_task`.
 - **Value marshalling** — the `value_*` family (below).
@@ -71,9 +71,10 @@ differences.
 
 ## Values (`laufey_value_t`)
 
-`laufey_value_t` is an opaque, dynamically-typed value used for everything crossing
-the JS ↔ native boundary (call arguments, results, menu templates, notification
-options). It models the JSON types plus binary blobs and JS-callback handles:
+`laufey_value_t` is an opaque, dynamically-typed value used for everything
+crossing the JS ↔ native boundary (call arguments, results, menu templates,
+notification options). It models the JSON types plus binary blobs and
+JS-callback handles:
 
 - **Inspect:** `value_is_null` / `_bool` / `_int` / `_double` / `_string` /
   `_list` / `_dict` / `_binary` / `_callback`.
@@ -100,8 +101,9 @@ and free it with `release_js_callback(id)`.
 
 1. The runtime exposes a namespace in the page (`set_js_namespace`, default
    `"Laufey"`) and registers `set_js_call_handler`.
-2. Page JS calls `Laufey.someMethod(args…)`; the backend invokes the handler with a
-   `call_id`, the method name, and the arguments as a `laufey_value_t` list.
+2. Page JS calls `Laufey.someMethod(args…)`; the backend invokes the handler
+   with a `call_id`, the method name, and the arguments as a `laufey_value_t`
+   list.
 3. The runtime does its work and replies with
    `js_call_respond(call_id, result,
    error)` — resolving or rejecting the

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -1,16 +1,16 @@
 # Packaging & distribution
 
-laufey stops at the backend and the runtime. A build produces a backend executable
-and your runtime shared library; turning that into something you can ship — and
-keeping it up to date — is the responsibility of the embedder that wraps laufey,
-not of laufey itself.
+laufey stops at the backend and the runtime. A build produces a backend
+executable and your runtime shared library; turning that into something you can
+ship — and keeping it up to date — is the responsibility of the embedder that
+wraps laufey, not of laufey itself.
 
 ## Bundling
 
-laufey does not produce an application bundle. The embedder decides how the backend
-executable and the runtime library are laid out and packaged: a macOS `.app`, a
-Windows installer or directory, a Linux `.deb`/AppImage, and so on. This is by
-design — laufey stays unopinionated so that a host such as the
+laufey does not produce an application bundle. The embedder decides how the
+backend executable and the runtime library are laid out and packaged: a macOS
+`.app`, a Windows installer or directory, a Linux `.deb`/AppImage, and so on.
+This is by design — laufey stays unopinionated so that a host such as the
 [`deno desktop`](https://github.com/denoland/deno) tooling can own the packaging
 format end to end.
 
@@ -20,9 +20,9 @@ the process running inside a real `.app` with a `CFBundleIdentifier`. An
 unbundled binary (run straight from `target/`, or the synthetic bundle
 `cargo
 run` produces) reports `unsupported` rather than failing, so those
-features come to life only once the embedder has bundled the app. laufey hard-codes
-no bundle identifier of its own, leaving the embedder free to set its own
-identity.
+features come to life only once the embedder has bundled the app. laufey
+hard-codes no bundle identifier of its own, leaving the embedder free to set its
+own identity.
 
 ## Code signing & notarization
 

--- a/docs/dock-taskbar.md
+++ b/docs/dock-taskbar.md
@@ -1,8 +1,8 @@
 # Dock / taskbar
 
-laufey can badge the application icon, request the user's attention, and — on macOS
-— drive the dock menu, the icon's visibility, and a reopen callback. These are
-free functions rather than window methods, because the dock is
+laufey can badge the application icon, request the user's attention, and — on
+macOS — drive the dock menu, the icon's visibility, and a reopen callback. These
+are free functions rather than window methods, because the dock is
 application-scoped on macOS, while on Windows and Linux the equivalent
 operations act on the currently focused window's taskbar button.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 <img src="laufey.png" alt="laufey" width="220" style="display: block; margin-bottom: 1rem;">
 
-**laufey** is a web embedded framework: build cross-platform desktop apps
-with web technologies and your choice of browser engine.
+**laufey** is a web embedded framework: build cross-platform desktop apps with
+web technologies and your choice of browser engine.
 
 It is built around a small C ABI that separates the **browser engine** (the
 backend) from your **application logic** (the runtime). You write the runtime in
@@ -32,8 +32,8 @@ laufey::main!(main);
 ## Where to go next
 
 - [Architecture](architecture.md) — how backends and runtimes fit together.
-- [C ABI](c-abi.md) — the `laufey.h` contract: entry points, the API table, and the
-  value model. Read this if you're implementing a backend or a binding.
+- [C ABI](c-abi.md) — the `laufey.h` contract: entry points, the API table, and
+  the value model. Read this if you're implementing a backend or a binding.
 - [Backends](backends.md) — CEF, WebView, and Winit, and how they differ.
 - The feature pages — [windows](window-management.md),
   [JavaScript interop](javascript-interop.md), [menus](menus.md),

--- a/docs/menus.md
+++ b/docs/menus.md
@@ -1,11 +1,11 @@
 # Menus
 
-laufey supports three kinds of menus: an application menu bar, per-window context
-menus, and the developer tools. A menu is described by a slice of `MenuItem`
-values, which can be regular items, submenus, separators, or standard roles such
-as quit, copy, and paste. Items may carry a keyboard accelerator. When the user
-clicks an item that has an identifier, your callback is invoked with that
-identifier.
+laufey supports three kinds of menus: an application menu bar, per-window
+context menus, and the developer tools. A menu is described by a slice of
+`MenuItem` values, which can be regular items, submenus, separators, or standard
+roles such as quit, copy, and paste. Items may carry a keyboard accelerator.
+When the user clicks an item that has an identifier, your callback is invoked
+with that identifier.
 
 ```rust
 use laufey::MenuItem;

--- a/examples/binding_test/Cargo.toml
+++ b/examples/binding_test/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "binding_test"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+laufey = { path = "../../capi" }
+tokio = { version = "1", features = ["rt-multi-thread", "time", "macros"] }

--- a/examples/binding_test/src/lib.rs
+++ b/examples/binding_test/src/lib.rs
@@ -1,0 +1,77 @@
+// Headless-ish bindings roundtrip check. Page runs echo/add cases on load,
+// reports PASS/FAIL lines back through a binding, which prints them and quits.
+// Regression guard for the macOS/Windows respond path that resolved every
+// binding call with null.
+
+use laufey::{Value, Window};
+
+fn binding_test_main() {
+  let rt = tokio::runtime::Runtime::new().unwrap();
+  rt.block_on(async {
+    let _win = Window::new(480, 320)
+      .title("Bindings Roundtrip Test")
+      .bind("echo", |call| {
+        let v = call.args.first().cloned().unwrap_or(Value::Null);
+        call.resolve(v);
+      })
+      .bind("add", |call| {
+        let a = call.args.first().and_then(|v| v.as_int()).unwrap_or(0);
+        let b = call.args.get(1).and_then(|v| v.as_int()).unwrap_or(0);
+        call.resolve(Value::Int(a + b));
+      })
+      .bind("report", |call| {
+        let report = call
+          .args
+          .first()
+          .and_then(|v| v.as_string())
+          .unwrap_or("(no report)")
+          .to_string();
+        println!("\n===== BINDINGS ROUNDTRIP =====\n{}\n==============================", report);
+        let all_pass = !report.contains("FAIL");
+        println!("RESULT: {}", if all_pass { "ALL PASS" } else { "FAILURES PRESENT" });
+        call.resolve(Value::Null);
+        laufey::quit();
+      })
+      .load(
+        r#"data:text/html,<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><title>roundtrip</title></head>
+<body>
+<pre id="out">running...</pre>
+<script>
+  const out = document.getElementById('out');
+  function eq(a, b) { return JSON.stringify(a) === JSON.stringify(b); }
+  async function run() {
+    const cases = [
+      ['echo string', () => Laufey.echo('hello'), 'hello'],
+      ['echo int',    () => Laufey.echo(42), 42],
+      ['echo bool',   () => Laufey.echo(true), true],
+      ['echo array',  () => Laufey.echo([1, 'two']), [1, 'two']],
+      ['echo object', () => Laufey.echo({a: 1}), {a: 1}],
+      ['echo null',   () => Laufey.echo(null), null],
+      ['add',         () => Laufey.add(2, 3), 5],
+    ];
+    const lines = [];
+    for (const [name, fn, want] of cases) {
+      try {
+        const got = await fn();
+        const ok = eq(got, want);
+        lines.push((ok ? 'PASS ' : 'FAIL ') + name + ' => got ' + JSON.stringify(got) + ' want ' + JSON.stringify(want));
+      } catch (e) {
+        lines.push('FAIL ' + name + ' threw ' + e.message);
+      }
+    }
+    out.textContent = lines.join('\n');
+    await Laufey.report(lines.join('\n'));
+  }
+  run();
+</script>
+</body>
+</html>"#,
+      );
+
+    laufey::run().await;
+  });
+}
+
+laufey::main!(binding_test_main);

--- a/webview/src/runtime_loader.cc
+++ b/webview/src/runtime_loader.cc
@@ -182,8 +182,7 @@ static void Backend_JsCallRespond(void* data, uint64_t call_id,
   // macOS/Windows decides resolve-vs-reject by the pointer's truthiness, so
   // fabricating a Value::Null() here would make every response look like a
   // rejection and resolve the JS promise with null.
-  laufey::ValuePtr errorPtr =
-      (error && error->value) ? error->value : nullptr;
+  laufey::ValuePtr errorPtr = (error && error->value) ? error->value : nullptr;
   loader->JsCallRespond(window_id, call_id, resultPtr, errorPtr);
 }
 

--- a/webview/src/runtime_loader.cc
+++ b/webview/src/runtime_loader.cc
@@ -178,8 +178,12 @@ static void Backend_JsCallRespond(void* data, uint64_t call_id,
   uint32_t window_id = loader->ConsumeCallWindow(call_id);
   laufey::ValuePtr resultPtr =
       (result && result->value) ? result->value : laufey::Value::Null();
+  // Keep the absent-error case as a genuine null pointer. RespondToJsCall on
+  // macOS/Windows decides resolve-vs-reject by the pointer's truthiness, so
+  // fabricating a Value::Null() here would make every response look like a
+  // rejection and resolve the JS promise with null.
   laufey::ValuePtr errorPtr =
-      (error && error->value) ? error->value : laufey::Value::Null();
+      (error && error->value) ? error->value : nullptr;
   loader->JsCallRespond(window_id, call_id, resultPtr, errorPtr);
 }
 


### PR DESCRIPTION
## Problem

webview binding calls (`laufey.echo(...)`, etc.) always resolved to `null` on macOS and Windows, regardless of the real return value. Visible in the "Desktop Feature Test" harness: every `Bindings Roundtrip` case fails returning `null` (only `echo(null) => null` "passes", trivially).

## Root cause

`Backend_JsCallRespond` (`webview/src/runtime_loader.cc`) unwraps the Rust-side `laufey_value_t*` into a `laufey::ValuePtr`. For the absent-error case (a normal resolve) it fabricated a **non-null** `Value::Null()`:

```cpp
laufey::ValuePtr errorPtr =
    (error && error->value) ? error->value : laufey::Value::Null();
```

The macOS (`webview_macos.mm`) and Windows (`webview_windows.cc`) `RespondToJsCall` decide resolve-vs-reject by pointer truthiness — `static_cast<bool>(error)`. Since `errorPtr` was always non-null, every response was treated as a rejection and emitted:

```js
window.__laufeyRespond(callId, null, null)
```

In the injected bridge, `error` is falsy there, so the promise resolves — with the discarded `null` result. Linux was unaffected because it guards with `(error && !error->IsNull())`.

## Fix

Pass a genuine null pointer when there is no error, so the truthiness check is meaningful:

```cpp
laufey::ValuePtr errorPtr =
    (error && error->value) ? error->value : nullptr;
```

One-line fix at the single shared source; covers macOS + Windows, Linux short-circuits safely.

## Test

- `webview` backend builds clean with the change (`runtime_loader.cc` TU compiles; full app bundle links).