### PR TITLE
feat: custom URL scheme handler for in-process app transport (API v26)

### DIFF
--- a/capi/include/laufey.h
+++ b/capi/include/laufey.h
@@ -11,7 +11,7 @@
 extern "C" {
 #endif
 
-#define LAUFEY_API_VERSION 25
+#define LAUFEY_API_VERSION 26
 
 // Window handle types for get_window_handle_type
 #define LAUFEY_WINDOW_HANDLE_UNKNOWN 0
@@ -223,6 +223,39 @@ typedef void (*laufey_keyboard_event_fn)(
 
 // Callback for window close requested events.
 typedef void (*laufey_close_requested_fn)(void* user_data, uint32_t window_id);
+
+// --- Custom URL scheme handler (in-process app transport, API >= 26) --------
+//
+// A custom scheme handler lets the embedder service webview requests for a
+// registered URL scheme (e.g. "app://...") entirely in-process, with no network
+// socket. The backend delivers each request to a laufey_scheme_request_fn and
+// the embedder streams a response back through the scheme_response_* vtable
+// functions. Both request and response bodies are streamed.
+//
+// Header lists are encoded as a flat buffer of NUL-terminated strings laid out
+// as name, value, name, value, ... -- `headers_len` is the total byte length
+// including every terminating NUL. Header names are lowercase.
+
+// Opaque handle for one in-flight scheme exchange. Valid from the moment the
+// request callback fires until scheme_response_finish releases it.
+typedef struct laufey_scheme_exchange laufey_scheme_exchange_t;
+
+// Invoked when the webview issues a request for a registered scheme. Runs on a
+// backend-internal thread; the embedder must not block it. `exchange` is used
+// for every subsequent streaming call and is owned by the embedder, which must
+// eventually call scheme_response_finish to release it. The request body (if
+// any) is pulled via scheme_request_read_body.
+typedef void (*laufey_scheme_request_fn)(void* user_data, uint32_t window_id,
+                                         laufey_scheme_exchange_t* exchange,
+                                         const char* method, const char* url,
+                                         const char* headers,
+                                         size_t headers_len);
+
+// Invoked if the webview cancels the request (navigation away, window closed)
+// before the response is finished. After this fires the embedder must stop
+// writing and call scheme_response_finish to release `exchange`. Optional.
+typedef void (*laufey_scheme_cancel_fn)(void* user_data,
+                                        laufey_scheme_exchange_t* exchange);
 
 struct laufey_backend_api {
   uint32_t version;
@@ -582,6 +615,46 @@ struct laufey_backend_api {
   // UNSUPPORTED.
   void (*request_permission)(void* backend_data, int kind,
                              laufey_permission_callback_fn cb, void* user_data);
+
+  // --- Custom URL scheme handler (API >= 26) ---------------------------------
+  //
+  // Register `handler` to service every request for `scheme` (the scheme name
+  // only, e.g. "app", without "://"). Must be called before any window
+  // navigates to that scheme. A NULL handler unregisters. `on_cancel` may be
+  // NULL. Backends added before API version 26 leave these four pointers NULL;
+  // callers must null-check and fall back to a socket transport.
+  void (*register_scheme_handler)(void* backend_data, const char* scheme,
+                                  laufey_scheme_request_fn handler,
+                                  laufey_scheme_cancel_fn on_cancel,
+                                  void* user_data);
+
+  // Pull up to `cap` bytes of the request body into `buf`. Returns the number
+  // of bytes read (>0), 0 at end of body, or -1 on error. May block until body
+  // data is available, so the embedder should call it off the critical path of
+  // its async runtime (a request with no body returns 0 immediately).
+  intptr_t (*scheme_request_read_body)(void* backend_data,
+                                       laufey_scheme_exchange_t* exchange,
+                                       uint8_t* buf, size_t cap);
+
+  // Send the response status code and headers. Must be called exactly once,
+  // before the first scheme_response_write. `headers` uses the flat encoding
+  // documented above; pass NULL/0 for none.
+  void (*scheme_response_begin)(void* backend_data,
+                                laufey_scheme_exchange_t* exchange, int status,
+                                const char* headers, size_t headers_len);
+
+  // Append `len` bytes to the response body. May be called repeatedly after
+  // scheme_response_begin. Returns the bytes accepted, or -1 if the consumer
+  // has gone away (the embedder should then stop and call
+  // scheme_response_finish).
+  intptr_t (*scheme_response_write)(void* backend_data,
+                                    laufey_scheme_exchange_t* exchange,
+                                    const uint8_t* buf, size_t len);
+
+  // Complete the response and release `exchange`. After this returns the handle
+  // is invalid. Call exactly once per exchange (including after a cancel).
+  void (*scheme_response_finish)(void* backend_data,
+                                 laufey_scheme_exchange_t* exchange);
 };
 
 #ifdef __cplusplus

--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -29,7 +29,7 @@ pub use mouse::*;
 /// (`github.com/denoland/laufey/releases/tag/v{VERSION}`).
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-pub const LAUFEY_API_VERSION: u32 = 25;
+pub const LAUFEY_API_VERSION: u32 = 26;
 
 /// Creation-time window style flags for [`Window::new_with_options`].
 /// Mirror the `LAUFEY_WINDOW_FLAG_*` constants in `laufey.h`.
@@ -473,6 +473,182 @@ pub async fn run() {
     poll_js_calls();
     if should_shutdown() {
       break;
+    }
+  }
+}
+
+// --- Custom URL scheme handler (in-process app transport) -------------------
+
+static SCHEME_HANDLER: OnceLock<
+  Mutex<Option<Box<dyn Fn(SchemeRequest) + Send + Sync>>>,
+> = OnceLock::new();
+
+fn scheme_handler_store(
+) -> &'static Mutex<Option<Box<dyn Fn(SchemeRequest) + Send + Sync>>> {
+  SCHEME_HANDLER.get_or_init(|| Mutex::new(None))
+}
+
+/// One in-flight scheme request/response exchange. Bridges a webview request
+/// for a registered scheme to the embedder, which streams a response back.
+pub struct SchemeRequest {
+  pub window_id: u32,
+  pub method: String,
+  pub url: String,
+  pub headers: Vec<(String, String)>,
+  pub exchange: SchemeExchange,
+}
+
+/// Handle used to read the request body and stream the response back to the
+/// webview. Backed by the backend's `scheme_*` vtable functions.
+pub struct SchemeExchange(*mut ffi::laufey_scheme_exchange_t);
+
+// The exchange handle is owned and synchronized by the backend; the embedder
+// may move it across threads and share references across them (e.g. hold a
+// `&SchemeExchange` across an await on a multi-threaded tokio runtime). Every
+// method forwards to a backend vtable function that synchronizes internally.
+unsafe impl Send for SchemeExchange {}
+unsafe impl Sync for SchemeExchange {}
+
+impl SchemeExchange {
+  /// Pull up to `buf.len()` bytes of the request body. Returns bytes read
+  /// (>0), 0 at end of body, or a negative value on error.
+  pub fn read_body(&self, buf: &mut [u8]) -> isize {
+    let api = api();
+    match api.scheme_request_read_body {
+      Some(f) => unsafe {
+        f(api.backend_data, self.0, buf.as_mut_ptr(), buf.len())
+      },
+      None => -1,
+    }
+  }
+
+  /// Send the response status and headers. Call once, before `write`.
+  pub fn begin(&self, status: i32, headers: &[(String, String)]) {
+    let api = api();
+    if let Some(f) = api.scheme_response_begin {
+      let flat = flatten_headers(headers);
+      unsafe {
+        f(
+          api.backend_data,
+          self.0,
+          status as c_int,
+          flat.as_ptr() as *const c_char,
+          flat.len(),
+        )
+      };
+    }
+  }
+
+  /// Append response body bytes. Returns bytes accepted, or a negative value
+  /// if the webview has gone away (the embedder should then stop and drop
+  /// the exchange via `finish`).
+  pub fn write(&self, buf: &[u8]) -> isize {
+    let api = api();
+    match api.scheme_response_write {
+      Some(f) => unsafe {
+        f(api.backend_data, self.0, buf.as_ptr(), buf.len())
+      },
+      None => -1,
+    }
+  }
+
+  /// Complete the response and release the exchange.
+  pub fn finish(self) {
+    let api = api();
+    if let Some(f) = api.scheme_response_finish {
+      unsafe { f(api.backend_data, self.0) };
+    }
+  }
+}
+
+fn flatten_headers(headers: &[(String, String)]) -> Vec<u8> {
+  let mut out = Vec::new();
+  for (name, value) in headers {
+    out.extend_from_slice(name.as_bytes());
+    out.push(0);
+    out.extend_from_slice(value.as_bytes());
+    out.push(0);
+  }
+  out
+}
+
+unsafe fn parse_flat_headers(
+  ptr: *const c_char,
+  len: usize,
+) -> Vec<(String, String)> {
+  if ptr.is_null() || len == 0 {
+    return Vec::new();
+  }
+  let bytes = unsafe { std::slice::from_raw_parts(ptr as *const u8, len) };
+  let mut out = Vec::new();
+  let mut parts = bytes.split(|&b| b == 0);
+  loop {
+    let (Some(name), Some(value)) = (parts.next(), parts.next()) else {
+      break;
+    };
+    if name.is_empty() && value.is_empty() {
+      break;
+    }
+    out.push((
+      String::from_utf8_lossy(name).into_owned(),
+      String::from_utf8_lossy(value).into_owned(),
+    ));
+  }
+  out
+}
+
+unsafe extern "C" fn scheme_request_trampoline(
+  _user_data: *mut c_void,
+  window_id: u32,
+  exchange: *mut ffi::laufey_scheme_exchange_t,
+  method: *const c_char,
+  url: *const c_char,
+  headers: *const c_char,
+  headers_len: usize,
+) {
+  let to_string = |p: *const c_char| {
+    if p.is_null() {
+      String::new()
+    } else {
+      unsafe { CStr::from_ptr(p) }.to_string_lossy().into_owned()
+    }
+  };
+  let req = SchemeRequest {
+    window_id,
+    method: to_string(method),
+    url: to_string(url),
+    headers: unsafe { parse_flat_headers(headers, headers_len) },
+    exchange: SchemeExchange(exchange),
+  };
+  let store = scheme_handler_store().lock().unwrap();
+  if let Some(handler) = store.as_ref() {
+    handler(req);
+  } else {
+    // No handler registered: release the exchange so the webview isn't hung.
+    req.exchange.finish();
+  }
+}
+
+/// Register `handler` to service every webview request for `scheme` (the
+/// scheme name only, e.g. `"app"`). The handler runs on a backend-internal
+/// thread and must not block it; offload work (e.g. onto a tokio task).
+/// Requires a backend built against laufey API version 26 or newer.
+pub fn register_scheme_handler<F>(scheme: &str, handler: F)
+where
+  F: Fn(SchemeRequest) + Send + Sync + 'static,
+{
+  *scheme_handler_store().lock().unwrap() = Some(Box::new(handler));
+  let api = api();
+  if let Some(register) = api.register_scheme_handler {
+    let c_scheme = CString::new(scheme).expect("scheme contains NUL");
+    unsafe {
+      register(
+        api.backend_data,
+        c_scheme.as_ptr(),
+        Some(scheme_request_trampoline),
+        None,
+        std::ptr::null_mut(),
+      );
     }
   }
 }

--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -582,10 +582,7 @@ unsafe fn parse_flat_headers(
   let bytes = unsafe { std::slice::from_raw_parts(ptr as *const u8, len) };
   let mut out = Vec::new();
   let mut parts = bytes.split(|&b| b == 0);
-  loop {
-    let (Some(name), Some(value)) = (parts.next(), parts.next()) else {
-      break;
-    };
+  while let (Some(name), Some(value)) = (parts.next(), parts.next()) {
     if name.is_empty() && value.is_empty() {
       break;
     }

--- a/cef/CMakeLists.txt
+++ b/cef/CMakeLists.txt
@@ -61,6 +61,8 @@ if(OS_MAC)
   set(LAUFEY_SRCS_COMMON
     src/app.cc
     src/app.h
+    src/scheme_handler.cc
+    src/scheme_handler.h
     src/runtime_loader.cc
     src/runtime_loader_mac.mm
     src/runtime_loader.h
@@ -172,6 +174,8 @@ elseif(OS_WINDOWS)
   set(LAUFEY_SRCS_COMMON
     src/app.cc
     src/app.h
+    src/scheme_handler.cc
+    src/scheme_handler.h
     src/runtime_loader.cc
     src/runtime_loader.h
   )
@@ -224,6 +228,8 @@ elseif(OS_LINUX)
   set(LAUFEY_SRCS_COMMON
     src/app.cc
     src/app.h
+    src/scheme_handler.cc
+    src/scheme_handler.h
     src/runtime_loader.cc
     src/runtime_loader.h
   )

--- a/cef/src/app.cc
+++ b/cef/src/app.cc
@@ -379,9 +379,9 @@ bool LaufeyHandler::OnProcessMessageReceived(
 void LaufeyApp::OnRegisterCustomSchemes(
     CefRawPtr<CefSchemeRegistrar> registrar) {
   registrar->AddCustomScheme(
-      LAUFEY_APP_SCHEME,
-      CEF_SCHEME_OPTION_STANDARD | CEF_SCHEME_OPTION_SECURE |
-          CEF_SCHEME_OPTION_CORS_ENABLED | CEF_SCHEME_OPTION_FETCH_ENABLED);
+      LAUFEY_APP_SCHEME, CEF_SCHEME_OPTION_STANDARD | CEF_SCHEME_OPTION_SECURE |
+                             CEF_SCHEME_OPTION_CORS_ENABLED |
+                             CEF_SCHEME_OPTION_FETCH_ENABLED);
 }
 
 void LaufeyApp::OnContextInitialized() {

--- a/cef/src/app.cc
+++ b/cef/src/app.cc
@@ -3,6 +3,7 @@
 #include "app.h"
 #include "runtime_loader.h"
 #include "laufey_backend_common.h"
+#include "scheme_handler.h"
 
 #include <iostream>
 
@@ -373,6 +374,14 @@ bool LaufeyHandler::OnProcessMessageReceived(
   }
 
   return false;
+}
+
+void LaufeyApp::OnRegisterCustomSchemes(
+    CefRawPtr<CefSchemeRegistrar> registrar) {
+  registrar->AddCustomScheme(
+      LAUFEY_APP_SCHEME,
+      CEF_SCHEME_OPTION_STANDARD | CEF_SCHEME_OPTION_SECURE |
+          CEF_SCHEME_OPTION_CORS_ENABLED | CEF_SCHEME_OPTION_FETCH_ENABLED);
 }
 
 void LaufeyApp::OnContextInitialized() {

--- a/cef/src/app.h
+++ b/cef/src/app.h
@@ -132,6 +132,12 @@ class LaufeyApp : public CefApp, public CefBrowserProcessHandler {
 
   void OnContextInitialized() override;
 
+  // Register the custom "app" scheme (standard, secure, fetch/CORS-enabled) so
+  // the in-process scheme handler can serve pages over app:// like an https
+  // origin. Called early in every process.
+  void OnRegisterCustomSchemes(
+      CefRawPtr<CefSchemeRegistrar> registrar) override;
+
 #if defined(__APPLE__)
   // Drive CefDoMessageLoopWork from the main run loop (external_message_pump)
   // so the libdispatch main queue keeps draining — tray/status-item creation

--- a/cef/src/runtime_loader.cc
+++ b/cef/src/runtime_loader.cc
@@ -594,9 +594,10 @@ static void Backend_JsCallRespond(void* data, uint64_t call_id,
 
 // --- Custom URL scheme handling ---
 
-static void Backend_RegisterSchemeHandler(
-    void* data, const char* scheme, laufey_scheme_request_fn handler,
-    laufey_scheme_cancel_fn on_cancel, void* user_data) {
+static void Backend_RegisterSchemeHandler(void* data, const char* scheme,
+                                          laufey_scheme_request_fn handler,
+                                          laufey_scheme_cancel_fn on_cancel,
+                                          void* user_data) {
   RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);
   loader->SetSchemeRequestHandler(scheme ? scheme : "", handler, on_cancel,
                                   user_data);
@@ -1659,9 +1660,10 @@ void RuntimeLoader::PollPendingJsCalls() {
   }
 }
 
-void RuntimeLoader::SetSchemeRequestHandler(
-    const std::string& scheme, laufey_scheme_request_fn handler,
-    laufey_scheme_cancel_fn on_cancel, void* user_data) {
+void RuntimeLoader::SetSchemeRequestHandler(const std::string& scheme,
+                                            laufey_scheme_request_fn handler,
+                                            laufey_scheme_cancel_fn on_cancel,
+                                            void* user_data) {
   bool need_register = false;
   std::string scheme_to_register;
   {

--- a/cef/src/runtime_loader.cc
+++ b/cef/src/runtime_loader.cc
@@ -3,6 +3,7 @@
 #include "runtime_loader.h"
 #include "app.h"
 #include "laufey_backend_common.h"
+#include "scheme_handler.h"
 
 #ifndef _WIN32
 #include <dlfcn.h>
@@ -589,6 +590,43 @@ static void Backend_JsCallRespond(void* data, uint64_t call_id,
                     b->GetMainFrame()->SendProcessMessage(PID_RENDERER, m);
                   },
                   browser, msg));
+}
+
+// --- Custom URL scheme handling ---
+
+static void Backend_RegisterSchemeHandler(
+    void* data, const char* scheme, laufey_scheme_request_fn handler,
+    laufey_scheme_cancel_fn on_cancel, void* user_data) {
+  RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);
+  loader->SetSchemeRequestHandler(scheme ? scheme : "", handler, on_cancel,
+                                  user_data);
+}
+
+static intptr_t Backend_SchemeRequestReadBody(
+    void* /*data*/, laufey_scheme_exchange_t* exchange, uint8_t* buf,
+    size_t cap) {
+  return reinterpret_cast<LaufeySchemeHandler*>(exchange)->ReadRequestBody(buf,
+                                                                           cap);
+}
+
+static void Backend_SchemeResponseBegin(void* /*data*/,
+                                        laufey_scheme_exchange_t* exchange,
+                                        int status, const char* headers,
+                                        size_t headers_len) {
+  reinterpret_cast<LaufeySchemeHandler*>(exchange)->Begin(status, headers,
+                                                          headers_len);
+}
+
+static intptr_t Backend_SchemeResponseWrite(void* /*data*/,
+                                            laufey_scheme_exchange_t* exchange,
+                                            const uint8_t* buf, size_t len) {
+  return reinterpret_cast<LaufeySchemeHandler*>(exchange)->WriteResponse(buf,
+                                                                         len);
+}
+
+static void Backend_SchemeResponseFinish(void* /*data*/,
+                                         laufey_scheme_exchange_t* exchange) {
+  reinterpret_cast<LaufeySchemeHandler*>(exchange)->FinishResponse();
 }
 
 static void Backend_InvokeJsCallback(void* data, uint64_t callback_id,
@@ -1299,6 +1337,12 @@ void RuntimeLoader::InitializeBackendApi() {
     loader->SetJsCallNotify(notify_fn, notify_data);
   };
 
+  backend_api_.register_scheme_handler = Backend_RegisterSchemeHandler;
+  backend_api_.scheme_request_read_body = Backend_SchemeRequestReadBody;
+  backend_api_.scheme_response_begin = Backend_SchemeResponseBegin;
+  backend_api_.scheme_response_write = Backend_SchemeResponseWrite;
+  backend_api_.scheme_response_finish = Backend_SchemeResponseFinish;
+
 #if defined(_WIN32)
   backend_api_.set_application_menu = Backend_SetApplicationMenu;
   backend_api_.show_context_menu = Backend_ShowContextMenu;
@@ -1612,5 +1656,55 @@ void RuntimeLoader::PollPendingJsCalls() {
           laufey::Value::String("No JS call handler registered"));
       Backend_JsCallRespond(this, call.call_id, nullptr, &errWrapper);
     }
+  }
+}
+
+void RuntimeLoader::SetSchemeRequestHandler(
+    const std::string& scheme, laufey_scheme_request_fn handler,
+    laufey_scheme_cancel_fn on_cancel, void* user_data) {
+  bool need_register = false;
+  std::string scheme_to_register;
+  {
+    std::lock_guard<std::mutex> lock(scheme_mutex_);
+    scheme_request_handler_ = handler;
+    scheme_cancel_handler_ = on_cancel;
+    scheme_user_data_ = user_data;
+    scheme_name_ = scheme;
+    if (handler && !scheme_factory_registered_) {
+      scheme_factory_registered_ = true;
+      need_register = true;
+      scheme_to_register = scheme;
+    }
+  }
+  if (need_register) {
+    // CefRegisterSchemeHandlerFactory must run on the UI thread.
+    CefPostTask(TID_UI, base::BindOnce(
+                            [](std::string s) {
+                              CefRegisterSchemeHandlerFactory(
+                                  s, "", new LaufeySchemeHandlerFactory());
+                            },
+                            scheme_to_register));
+  }
+}
+
+void RuntimeLoader::DispatchSchemeRequest(uint32_t window_id, void* exchange,
+                                          const std::string& method,
+                                          const std::string& url,
+                                          const std::string& flat_headers) {
+  laufey_scheme_request_fn handler;
+  void* user_data;
+  {
+    std::lock_guard<std::mutex> lock(scheme_mutex_);
+    handler = scheme_request_handler_;
+    user_data = scheme_user_data_;
+  }
+  if (handler) {
+    handler(user_data, window_id,
+            reinterpret_cast<laufey_scheme_exchange_t*>(exchange),
+            method.c_str(), url.c_str(), flat_headers.data(),
+            flat_headers.size());
+  } else {
+    // No handler registered: finish the exchange so the request doesn't hang.
+    reinterpret_cast<LaufeySchemeHandler*>(exchange)->FinishResponse();
   }
 }

--- a/cef/src/runtime_loader.h
+++ b/cef/src/runtime_loader.h
@@ -295,6 +295,21 @@ class RuntimeLoader {
     }
   }
 
+  // --- Custom URL scheme handler (API >= 26) ---
+  // Store the runtime's scheme request handler and lazily install the CEF
+  // scheme handler factory (on the UI thread) the first time a scheme is
+  // registered.
+  void SetSchemeRequestHandler(const std::string& scheme,
+                               laufey_scheme_request_fn handler,
+                               laufey_scheme_cancel_fn on_cancel,
+                               void* user_data);
+
+  // Invoke the registered scheme request handler. Called from a CEF IO thread
+  // by the scheme handler factory; `exchange` is the LaufeySchemeHandler.
+  void DispatchSchemeRequest(uint32_t window_id, void* exchange,
+                             const std::string& method, const std::string& url,
+                             const std::string& flat_headers);
+
   void SetJsCallNotify(void (*notify_fn)(void*), void* notify_data) {
     std::lock_guard<std::mutex> lock(notify_mutex_);
     js_call_notify_fn_ = notify_fn;
@@ -392,6 +407,13 @@ class RuntimeLoader {
   void (*js_call_notify_fn_)(void*) = nullptr;
   void* js_call_notify_data_ = nullptr;
   std::mutex notify_mutex_;
+
+  laufey_scheme_request_fn scheme_request_handler_ = nullptr;
+  laufey_scheme_cancel_fn scheme_cancel_handler_ = nullptr;
+  void* scheme_user_data_ = nullptr;
+  std::string scheme_name_;
+  bool scheme_factory_registered_ = false;
+  std::mutex scheme_mutex_;
 
   std::string js_namespace_ = "Laufey";
   mutable std::mutex js_namespace_mutex_;

--- a/cef/src/scheme_handler.cc
+++ b/cef/src/scheme_handler.cc
@@ -62,8 +62,8 @@ bool LaufeySchemeHandler::Open(CefRefPtr<CefRequest> request,
   // Hand ownership of an extra reference to the runtime. Released in
   // FinishResponse(). Keeps the handler alive while the runtime streams.
   this->AddRef();
-  RuntimeLoader::GetInstance()->DispatchSchemeRequest(
-      window_id_, this, method_, url_, flat_headers);
+  RuntimeLoader::GetInstance()->DispatchSchemeRequest(window_id_, this, method_,
+                                                      url_, flat_headers);
   return true;
 }
 
@@ -98,8 +98,8 @@ bool LaufeySchemeHandler::Read(void* data_out, int bytes_to_read,
   std::lock_guard<std::mutex> lock(mutex_);
 
   if (!response_body_.empty()) {
-    size_t n = std::min(static_cast<size_t>(bytes_to_read),
-                        response_body_.size());
+    size_t n =
+        std::min(static_cast<size_t>(bytes_to_read), response_body_.size());
     std::copy(response_body_.begin(), response_body_.begin() + n,
               static_cast<uint8_t*>(data_out));
     response_body_.erase(response_body_.begin(), response_body_.begin() + n);
@@ -112,21 +112,27 @@ bool LaufeySchemeHandler::Read(void* data_out, int bytes_to_read,
     return false;  // EOF
   }
 
-  // No data yet: park the read and resume when WriteResponse/FinishResponse
-  // calls Continue(), at which point CEF re-invokes Read.
+  // No data yet: keep the output buffer + callback, fill them when
+  // WriteResponse/FinishResponse arrives and resume via Continue(n).
+  pending_data_ = data_out;
+  pending_cap_ = bytes_to_read;
   read_callback_ = callback;
   bytes_read = 0;
   return true;
 }
 
 void LaufeySchemeHandler::Cancel() {
-  std::lock_guard<std::mutex> lock(mutex_);
-  cancelled_ = true;
-  // Wake any parked read so it observes the cancel and reports EOF.
-  if (read_callback_) {
-    read_callback_->Continue();
+  CefRefPtr<CefResourceReadCallback> to_continue;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    cancelled_ = true;
+    to_continue = read_callback_;
     read_callback_ = nullptr;
+    pending_data_ = nullptr;
   }
+  // Wake any parked read so it reports EOF.
+  if (to_continue)
+    to_continue->Continue(0);
 }
 
 intptr_t LaufeySchemeHandler::ReadRequestBody(uint8_t* buf, size_t cap) {
@@ -177,16 +183,27 @@ void LaufeySchemeHandler::Begin(int status, const char* headers,
 
 intptr_t LaufeySchemeHandler::WriteResponse(const uint8_t* buf, size_t len) {
   CefRefPtr<CefResourceReadCallback> to_continue;
+  int to_report = 0;
   {
     std::lock_guard<std::mutex> lock(mutex_);
     if (cancelled_)
       return -1;
     response_body_.insert(response_body_.end(), buf, buf + len);
-    to_continue = read_callback_;
-    read_callback_ = nullptr;
+    // Satisfy a parked Read by copying into its output buffer.
+    if (read_callback_ && pending_data_ && !response_body_.empty()) {
+      size_t n =
+          std::min(static_cast<size_t>(pending_cap_), response_body_.size());
+      std::copy(response_body_.begin(), response_body_.begin() + n,
+                static_cast<uint8_t*>(pending_data_));
+      response_body_.erase(response_body_.begin(), response_body_.begin() + n);
+      to_report = static_cast<int>(n);
+      to_continue = read_callback_;
+      read_callback_ = nullptr;
+      pending_data_ = nullptr;
+    }
   }
   if (to_continue)
-    to_continue->Continue();
+    to_continue->Continue(to_report);
   return static_cast<intptr_t>(len);
 }
 
@@ -197,9 +214,11 @@ void LaufeySchemeHandler::FinishResponse() {
     finished_ = true;
     to_continue = read_callback_;
     read_callback_ = nullptr;
+    pending_data_ = nullptr;
   }
+  // A parked read with no remaining body: report EOF.
   if (to_continue)
-    to_continue->Continue();
+    to_continue->Continue(0);
   // Release the reference taken in Open(); may destroy this handler.
   this->Release();
 }

--- a/cef/src/scheme_handler.cc
+++ b/cef/src/scheme_handler.cc
@@ -1,0 +1,213 @@
+// Copyright 2025 Divy Srivastava. All rights reserved. MIT license.
+
+#include "scheme_handler.h"
+
+#include <algorithm>
+#include <cstring>
+
+#include "include/cef_request.h"
+#include "include/cef_response.h"
+#include "runtime_loader.h"
+
+namespace {
+
+// Flatten a CEF header map into laufey's NUL-separated name\0value\0... wire
+// format (lowercasing names to match fetch/HTTP conventions).
+std::string FlattenHeaders(const CefRequest::HeaderMap& headers) {
+  std::string out;
+  for (const auto& [key, value] : headers) {
+    std::string name = key.ToString();
+    std::transform(name.begin(), name.end(), name.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+    out.append(name);
+    out.push_back('\0');
+    out.append(value.ToString());
+    out.push_back('\0');
+  }
+  return out;
+}
+
+}  // namespace
+
+bool LaufeySchemeHandler::Open(CefRefPtr<CefRequest> request,
+                               bool& handle_request,
+                               CefRefPtr<CefCallback> callback) {
+  method_ = request->GetMethod().ToString();
+  url_ = request->GetURL().ToString();
+
+  CefRequest::HeaderMap header_map;
+  request->GetHeaderMap(header_map);
+  std::string flat_headers = FlattenHeaders(header_map);
+
+  // Buffer the request body up front. CEF makes the full POST data available
+  // here, so the runtime's ReadRequestBody pulls become non-blocking copies.
+  CefRefPtr<CefPostData> post_data = request->GetPostData();
+  if (post_data) {
+    CefPostData::ElementVector elements;
+    post_data->GetElements(elements);
+    for (const auto& element : elements) {
+      size_t count = element->GetBytesCount();
+      if (count == 0)
+        continue;
+      size_t offset = request_body_.size();
+      request_body_.resize(offset + count);
+      element->GetBytes(count, request_body_.data() + offset);
+    }
+  }
+
+  // Defer until the runtime calls Begin(); resume via open_callback_.
+  open_callback_ = callback;
+  handle_request = false;
+
+  // Hand ownership of an extra reference to the runtime. Released in
+  // FinishResponse(). Keeps the handler alive while the runtime streams.
+  this->AddRef();
+  RuntimeLoader::GetInstance()->DispatchSchemeRequest(
+      window_id_, this, method_, url_, flat_headers);
+  return true;
+}
+
+void LaufeySchemeHandler::GetResponseHeaders(CefRefPtr<CefResponse> response,
+                                             int64_t& response_length,
+                                             CefString& redirectUrl) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  response->SetStatus(status_);
+
+  CefResponse::HeaderMap header_map;
+  std::string mime_type;
+  for (const auto& [name, value] : response_headers_) {
+    if (name == "content-type") {
+      // CefResponse exposes mime type separately; the full content-type
+      // (incl. charset) still round-trips via SetMimeType.
+      mime_type = value;
+    }
+    header_map.insert({name, value});
+  }
+  response->SetHeaderMap(header_map);
+  if (!mime_type.empty()) {
+    response->SetMimeType(mime_type);
+  }
+
+  // Streaming: length unknown until FinishResponse.
+  response_length = -1;
+}
+
+bool LaufeySchemeHandler::Read(void* data_out, int bytes_to_read,
+                               int& bytes_read,
+                               CefRefPtr<CefResourceReadCallback> callback) {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  if (!response_body_.empty()) {
+    size_t n = std::min(static_cast<size_t>(bytes_to_read),
+                        response_body_.size());
+    std::copy(response_body_.begin(), response_body_.begin() + n,
+              static_cast<uint8_t*>(data_out));
+    response_body_.erase(response_body_.begin(), response_body_.begin() + n);
+    bytes_read = static_cast<int>(n);
+    return true;
+  }
+
+  if (finished_ || cancelled_) {
+    bytes_read = 0;
+    return false;  // EOF
+  }
+
+  // No data yet: park the read and resume when WriteResponse/FinishResponse
+  // calls Continue(), at which point CEF re-invokes Read.
+  read_callback_ = callback;
+  bytes_read = 0;
+  return true;
+}
+
+void LaufeySchemeHandler::Cancel() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  cancelled_ = true;
+  // Wake any parked read so it observes the cancel and reports EOF.
+  if (read_callback_) {
+    read_callback_->Continue();
+    read_callback_ = nullptr;
+  }
+}
+
+intptr_t LaufeySchemeHandler::ReadRequestBody(uint8_t* buf, size_t cap) {
+  if (cap == 0)
+    return 0;
+  size_t remaining = request_body_.size() - request_body_cursor_;
+  if (remaining == 0)
+    return 0;  // EOF
+  size_t n = std::min(cap, remaining);
+  std::memcpy(buf, request_body_.data() + request_body_cursor_, n);
+  request_body_cursor_ += n;
+  return static_cast<intptr_t>(n);
+}
+
+void LaufeySchemeHandler::Begin(int status, const char* headers,
+                                size_t headers_len) {
+  CefRefPtr<CefCallback> to_continue;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    status_ = status;
+    response_headers_.clear();
+    // Parse the flat name\0value\0... encoding.
+    size_t i = 0;
+    while (i < headers_len) {
+      size_t name_end = i;
+      while (name_end < headers_len && headers[name_end] != '\0')
+        name_end++;
+      if (name_end >= headers_len)
+        break;
+      size_t value_start = name_end + 1;
+      size_t value_end = value_start;
+      while (value_end < headers_len && headers[value_end] != '\0')
+        value_end++;
+      if (value_end > headers_len)
+        break;
+      response_headers_.emplace_back(
+          std::string(headers + i, name_end - i),
+          std::string(headers + value_start, value_end - value_start));
+      i = value_end + 1;
+    }
+    began_ = true;
+    to_continue = open_callback_;
+    open_callback_ = nullptr;
+  }
+  if (to_continue)
+    to_continue->Continue();
+}
+
+intptr_t LaufeySchemeHandler::WriteResponse(const uint8_t* buf, size_t len) {
+  CefRefPtr<CefResourceReadCallback> to_continue;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (cancelled_)
+      return -1;
+    response_body_.insert(response_body_.end(), buf, buf + len);
+    to_continue = read_callback_;
+    read_callback_ = nullptr;
+  }
+  if (to_continue)
+    to_continue->Continue();
+  return static_cast<intptr_t>(len);
+}
+
+void LaufeySchemeHandler::FinishResponse() {
+  CefRefPtr<CefResourceReadCallback> to_continue;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    finished_ = true;
+    to_continue = read_callback_;
+    read_callback_ = nullptr;
+  }
+  if (to_continue)
+    to_continue->Continue();
+  // Release the reference taken in Open(); may destroy this handler.
+  this->Release();
+}
+
+CefRefPtr<CefResourceHandler> LaufeySchemeHandlerFactory::Create(
+    CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame,
+    const CefString& scheme_name, CefRefPtr<CefRequest> request) {
+  uint32_t window_id =
+      RuntimeLoader::GetInstance()->GetLaufeyIdForBrowser(browser);
+  return new LaufeySchemeHandler(window_id);
+}

--- a/cef/src/scheme_handler.h
+++ b/cef/src/scheme_handler.h
@@ -67,9 +67,14 @@ class LaufeySchemeHandler : public CefResourceHandler {
   bool finished_ = false;
   bool cancelled_ = false;
 
-  // Deferred CEF continuations.
+  // Deferred CEF continuations. When a Read arrives with no body buffered, the
+  // caller's output buffer (`pending_data_` / `pending_cap_`, valid until the
+  // callback fires) and `read_callback_` are stashed and satisfied once
+  // WriteResponse/FinishResponse provides data.
   CefRefPtr<CefCallback> open_callback_;
   CefRefPtr<CefResourceReadCallback> read_callback_;
+  void* pending_data_ = nullptr;
+  int pending_cap_ = 0;
 
   IMPLEMENT_REFCOUNTING(LaufeySchemeHandler);
 };

--- a/cef/src/scheme_handler.h
+++ b/cef/src/scheme_handler.h
@@ -1,0 +1,91 @@
+// Copyright 2025 Divy Srivastava. All rights reserved. MIT license.
+
+#ifndef LAUFEY_SCHEME_HANDLER_H_
+#define LAUFEY_SCHEME_HANDLER_H_
+
+#include <cstdint>
+#include <deque>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "include/cef_resource_handler.h"
+#include "include/cef_scheme.h"
+
+// The custom standard scheme laufey registers for in-process app serving
+// (e.g. "app://..."). Declared as a standard, secure, fetch/CORS-enabled
+// scheme in LaufeyApp::OnRegisterCustomSchemes so pages served over it behave
+// like normal https origins.
+#define LAUFEY_APP_SCHEME "app"
+
+// A CefResourceHandler that bridges a single webview request to the laufey
+// runtime's registered scheme handler. The handler object IS the opaque
+// `laufey_scheme_exchange_t` passed across the C ABI: the runtime pulls the
+// request body and streams the response back through the scheme_* vtable
+// functions, which call the methods below.
+//
+// Threading: Open/GetResponseHeaders/Read/Cancel run on a CEF IO thread; the
+// Begin/WriteResponse/FinishResponse/ReadRequestBody methods are called by the
+// runtime from its own thread. All shared state is guarded by `mutex_`, and
+// CEF's callbacks are resumed via Continue() (safe from any thread).
+class LaufeySchemeHandler : public CefResourceHandler {
+ public:
+  explicit LaufeySchemeHandler(uint32_t window_id) : window_id_(window_id) {}
+
+  // CefResourceHandler:
+  bool Open(CefRefPtr<CefRequest> request, bool& handle_request,
+            CefRefPtr<CefCallback> callback) override;
+  void GetResponseHeaders(CefRefPtr<CefResponse> response,
+                          int64_t& response_length,
+                          CefString& redirectUrl) override;
+  bool Read(void* data_out, int bytes_to_read, int& bytes_read,
+            CefRefPtr<CefResourceReadCallback> callback) override;
+  void Cancel() override;
+
+  // Called by the runtime (via the scheme_* vtable functions), off the IO
+  // thread. Return values mirror the C ABI contract.
+  intptr_t ReadRequestBody(uint8_t* buf, size_t cap);
+  void Begin(int status, const char* headers, size_t headers_len);
+  intptr_t WriteResponse(const uint8_t* buf, size_t len);
+  void FinishResponse();
+
+ private:
+  uint32_t window_id_;
+
+  // Request state (immutable after Open).
+  std::string method_;
+  std::string url_;
+  std::vector<uint8_t> request_body_;
+  size_t request_body_cursor_ = 0;
+
+  // Response state, guarded by mutex_.
+  std::mutex mutex_;
+  int status_ = 200;
+  std::vector<std::pair<std::string, std::string>> response_headers_;
+  std::deque<uint8_t> response_body_;
+  bool began_ = false;
+  bool finished_ = false;
+  bool cancelled_ = false;
+
+  // Deferred CEF continuations.
+  CefRefPtr<CefCallback> open_callback_;
+  CefRefPtr<CefResourceReadCallback> read_callback_;
+
+  IMPLEMENT_REFCOUNTING(LaufeySchemeHandler);
+};
+
+// Factory installed via CefRegisterSchemeHandlerFactory. Stateless: each
+// Create() builds a LaufeySchemeHandler and dispatches the request to the
+// runtime's registered handler through RuntimeLoader.
+class LaufeySchemeHandlerFactory : public CefSchemeHandlerFactory {
+ public:
+  CefRefPtr<CefResourceHandler> Create(CefRefPtr<CefBrowser> browser,
+                                       CefRefPtr<CefFrame> frame,
+                                       const CefString& scheme_name,
+                                       CefRefPtr<CefRequest> request) override;
+
+ private:
+  IMPLEMENT_REFCOUNTING(LaufeySchemeHandlerFactory);
+};
+
+#endif  // LAUFEY_SCHEME_HANDLER_H_

--- a/docs/c-abi.md
+++ b/docs/c-abi.md
@@ -124,19 +124,19 @@ registered URL scheme (e.g. `app://`) entirely in-process — no network socket,
 port, or `localhost` exposure. This is how the Deno desktop runtime serves an
 embedded browser over an in-memory byte channel instead of a TCP loopback.
 
-1. The runtime calls `register_scheme_handler(scheme, handler, on_cancel,
-   user_data)` with the scheme name (e.g. `"app"`, no `://`). The backend
-   registers it as a standard, secure, fetch/CORS-enabled scheme and installs a
-   handler factory.
+1. The runtime calls
+   `register_scheme_handler(scheme, handler, on_cancel,
+   user_data)` with the
+   scheme name (e.g. `"app"`, no `://`). The backend registers it as a standard,
+   secure, fetch/CORS-enabled scheme and installs a handler factory.
 2. When the webview requests `<scheme>://…`, the backend invokes `handler` with
    request metadata (method, URL, headers) and an opaque
-   `laufey_scheme_exchange_t*`. Headers use a flat
-   `name\0value\0…\0` encoding (`headers_len` counts every terminating NUL).
-3. The runtime pulls the request body (if any) with
-   `scheme_request_read_body` (returns >0 bytes, 0 at EOF, <0 on error), then
-   streams the response: `scheme_response_begin(status, headers)` once,
-   `scheme_response_write(bytes)` any number of times, and
-   `scheme_response_finish` to release the exchange.
+   `laufey_scheme_exchange_t*`. Headers use a flat `name\0value\0…\0` encoding
+   (`headers_len` counts every terminating NUL).
+3. The runtime pulls the request body (if any) with `scheme_request_read_body`
+   (returns >0 bytes, 0 at EOF, <0 on error), then streams the response:
+   `scheme_response_begin(status, headers)` once, `scheme_response_write(bytes)`
+   any number of times, and `scheme_response_finish` to release the exchange.
 
 If the webview cancels (navigation away, window closed) before the response
 finishes, `scheme_response_write` / `scheme_request_read_body` return negative;

--- a/docs/c-abi.md
+++ b/docs/c-abi.md
@@ -6,7 +6,7 @@ It defines the boundary between a **backend** (a native executable embedding a
 browser engine) and a **runtime** (a shared library holding the application
 logic). The backend implements the ABI; the runtime consumes it.
 
-`LAUFEY_API_VERSION` (currently `25`) versions the contract. The `version` field
+`LAUFEY_API_VERSION` (currently `26`) versions the contract. The `version` field
 on the API table lets a runtime detect the backend's vintage and avoid calling
 function pointers a backend predates (older backends leave new pointers `NULL`).
 
@@ -65,6 +65,9 @@ The pointers group into:
   `set_tray_tooltip`, `set_tray_menu`, click handlers, `get_tray_icon_bounds`.
 - **Notifications** — `show_notification`, `close_notification`.
 - **Permissions** — `query_permission`, `request_permission`.
+- **Custom URL scheme handler** (API ≥ 26) — `register_scheme_handler`,
+  `scheme_request_read_body`, `scheme_response_begin`, `scheme_response_write`,
+  `scheme_response_finish`.
 
 See [the feature pages](window-management.md) for behavior and per-platform
 differences.
@@ -113,6 +116,33 @@ and free it with `release_js_callback(id)`.
 `laufey_js_result_fn`. When the runtime services calls off the UI thread, the
 backend signals readiness via `set_js_call_notify` and the runtime drains the
 queue with `poll_js_calls`.
+
+## Custom URL scheme handler (API ≥ 26)
+
+A custom scheme handler lets the runtime service webview requests for a
+registered URL scheme (e.g. `app://`) entirely in-process — no network socket,
+port, or `localhost` exposure. This is how the Deno desktop runtime serves an
+embedded browser over an in-memory byte channel instead of a TCP loopback.
+
+1. The runtime calls `register_scheme_handler(scheme, handler, on_cancel,
+   user_data)` with the scheme name (e.g. `"app"`, no `://`). The backend
+   registers it as a standard, secure, fetch/CORS-enabled scheme and installs a
+   handler factory.
+2. When the webview requests `<scheme>://…`, the backend invokes `handler` with
+   request metadata (method, URL, headers) and an opaque
+   `laufey_scheme_exchange_t*`. Headers use a flat
+   `name\0value\0…\0` encoding (`headers_len` counts every terminating NUL).
+3. The runtime pulls the request body (if any) with
+   `scheme_request_read_body` (returns >0 bytes, 0 at EOF, <0 on error), then
+   streams the response: `scheme_response_begin(status, headers)` once,
+   `scheme_response_write(bytes)` any number of times, and
+   `scheme_response_finish` to release the exchange.
+
+If the webview cancels (navigation away, window closed) before the response
+finishes, `scheme_response_write` / `scheme_request_read_body` return negative;
+the runtime should stop and call `scheme_response_finish`. Backends predating
+API version 26 leave these pointers `NULL`; the runtime must null-check and fall
+back to a socket transport.
 
 ## Threading
 

--- a/webview/src/runtime_loader.cc
+++ b/webview/src/runtime_loader.cc
@@ -188,9 +188,10 @@ static void Backend_JsCallRespond(void* data, uint64_t call_id,
 
 // --- Custom URL scheme handling ---
 
-static void Backend_RegisterSchemeHandler(
-    void* data, const char* scheme, laufey_scheme_request_fn handler,
-    laufey_scheme_cancel_fn on_cancel, void* user_data) {
+static void Backend_RegisterSchemeHandler(void* data, const char* scheme,
+                                          laufey_scheme_request_fn handler,
+                                          laufey_scheme_cancel_fn on_cancel,
+                                          void* user_data) {
   RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);
   loader->SetSchemeRequestHandler(scheme ? scheme : "", handler, on_cancel,
                                   user_data);
@@ -782,9 +783,10 @@ void RuntimeLoader::Shutdown() {
   }
 }
 
-void RuntimeLoader::SetSchemeRequestHandler(
-    const std::string& scheme, laufey_scheme_request_fn handler,
-    laufey_scheme_cancel_fn on_cancel, void* user_data) {
+void RuntimeLoader::SetSchemeRequestHandler(const std::string& scheme,
+                                            laufey_scheme_request_fn handler,
+                                            laufey_scheme_cancel_fn on_cancel,
+                                            void* user_data) {
   {
     std::lock_guard<std::mutex> lock(scheme_mutex_);
     scheme_request_handler_ = handler;

--- a/webview/src/runtime_loader.cc
+++ b/webview/src/runtime_loader.cc
@@ -186,6 +186,43 @@ static void Backend_JsCallRespond(void* data, uint64_t call_id,
   loader->JsCallRespond(window_id, call_id, resultPtr, errorPtr);
 }
 
+// --- Custom URL scheme handling ---
+
+static void Backend_RegisterSchemeHandler(
+    void* data, const char* scheme, laufey_scheme_request_fn handler,
+    laufey_scheme_cancel_fn on_cancel, void* user_data) {
+  RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);
+  loader->SetSchemeRequestHandler(scheme ? scheme : "", handler, on_cancel,
+                                  user_data);
+}
+
+static intptr_t Backend_SchemeRequestReadBody(
+    void* /*data*/, laufey_scheme_exchange_t* exchange, uint8_t* buf,
+    size_t cap) {
+  return reinterpret_cast<SchemeExchangeBase*>(exchange)->ReadRequestBody(buf,
+                                                                          cap);
+}
+
+static void Backend_SchemeResponseBegin(void* /*data*/,
+                                        laufey_scheme_exchange_t* exchange,
+                                        int status, const char* headers,
+                                        size_t headers_len) {
+  reinterpret_cast<SchemeExchangeBase*>(exchange)->Begin(status, headers,
+                                                         headers_len);
+}
+
+static intptr_t Backend_SchemeResponseWrite(void* /*data*/,
+                                            laufey_scheme_exchange_t* exchange,
+                                            const uint8_t* buf, size_t len) {
+  return reinterpret_cast<SchemeExchangeBase*>(exchange)->WriteResponse(buf,
+                                                                        len);
+}
+
+static void Backend_SchemeResponseFinish(void* /*data*/,
+                                         laufey_scheme_exchange_t* exchange) {
+  reinterpret_cast<SchemeExchangeBase*>(exchange)->Finish();
+}
+
 static void Backend_InvokeJsCallback(void* data, uint64_t callback_id,
                                      laufey_value_t* args) {
   RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);
@@ -550,6 +587,12 @@ void RuntimeLoader::InitializeBackendApi() {
   backend_api_.set_js_call_handler = Backend_SetJsCallHandler;
   backend_api_.js_call_respond = Backend_JsCallRespond;
 
+  backend_api_.register_scheme_handler = Backend_RegisterSchemeHandler;
+  backend_api_.scheme_request_read_body = Backend_SchemeRequestReadBody;
+  backend_api_.scheme_response_begin = Backend_SchemeResponseBegin;
+  backend_api_.scheme_response_write = Backend_SchemeResponseWrite;
+  backend_api_.scheme_response_finish = Backend_SchemeResponseFinish;
+
   backend_api_.invoke_js_callback = Backend_InvokeJsCallback;
   backend_api_.release_js_callback = Backend_ReleaseJsCallback;
 
@@ -736,6 +779,43 @@ void RuntimeLoader::Shutdown() {
 
   if (runtime_thread_.joinable()) {
     runtime_thread_.join();
+  }
+}
+
+void RuntimeLoader::SetSchemeRequestHandler(
+    const std::string& scheme, laufey_scheme_request_fn handler,
+    laufey_scheme_cancel_fn on_cancel, void* user_data) {
+  {
+    std::lock_guard<std::mutex> lock(scheme_mutex_);
+    scheme_request_handler_ = handler;
+    scheme_cancel_handler_ = on_cancel;
+    scheme_user_data_ = user_data;
+  }
+  if (handler && backend_) {
+    backend_->RegisterSchemeHandler(scheme);
+  }
+}
+
+void RuntimeLoader::DispatchSchemeRequest(uint32_t window_id,
+                                          SchemeExchangeBase* exchange,
+                                          const std::string& method,
+                                          const std::string& url,
+                                          const std::string& flat_headers) {
+  laufey_scheme_request_fn handler;
+  void* user_data;
+  {
+    std::lock_guard<std::mutex> lock(scheme_mutex_);
+    handler = scheme_request_handler_;
+    user_data = scheme_user_data_;
+  }
+  if (handler) {
+    handler(user_data, window_id,
+            reinterpret_cast<laufey_scheme_exchange_t*>(exchange),
+            method.c_str(), url.c_str(), flat_headers.data(),
+            flat_headers.size());
+  } else {
+    // No handler registered: finish so the request doesn't hang.
+    exchange->Finish();
   }
 }
 

--- a/webview/src/runtime_loader.h
+++ b/webview/src/runtime_loader.h
@@ -11,6 +11,7 @@
 #include <map>
 
 #include "laufey.h"
+#include "scheme_exchange.h"
 #include "webview_value.h"
 
 #ifdef _WIN32
@@ -76,6 +77,20 @@ class RuntimeLoader {
     js_call_handler_ = handler;
     js_call_user_data_ = user_data;
   }
+
+  // --- Custom URL scheme handler (API >= 26) ---
+  // Store the runtime's scheme request handler and ask the platform backend to
+  // install its native handler for `scheme`.
+  void SetSchemeRequestHandler(const std::string& scheme,
+                               laufey_scheme_request_fn handler,
+                               laufey_scheme_cancel_fn on_cancel,
+                               void* user_data);
+
+  // Invoke the registered scheme request handler. Called by the platform
+  // backend when the webview issues a request for the registered scheme.
+  void DispatchSchemeRequest(uint32_t window_id, SchemeExchangeBase* exchange,
+                             const std::string& method, const std::string& url,
+                             const std::string& flat_headers);
 
   void SetKeyboardEventHandler(laufey_keyboard_event_fn handler,
                                void* user_data) {
@@ -246,6 +261,11 @@ class RuntimeLoader {
   void* js_call_user_data_ = nullptr;
   std::mutex handler_mutex_;
 
+  laufey_scheme_request_fn scheme_request_handler_ = nullptr;
+  laufey_scheme_cancel_fn scheme_cancel_handler_ = nullptr;
+  void* scheme_user_data_ = nullptr;
+  std::mutex scheme_mutex_;
+
   laufey_keyboard_event_fn keyboard_handler_ = nullptr;
   void* keyboard_user_data_ = nullptr;
   std::mutex keyboard_mutex_;
@@ -364,6 +384,12 @@ class LaufeyBackend {
                                void* on_click_data) = 0;
 
   virtual void OpenDevTools(uint32_t window_id) = 0;
+
+  // --- Custom URL scheme handler (API >= 26) ---
+  // Install a native handler for `scheme` so requests to <scheme>://… are
+  // delivered to RuntimeLoader::DispatchSchemeRequest. Default no-op: backends
+  // that don't implement it leave the scheme unhandled.
+  virtual void RegisterSchemeHandler(const std::string& /*scheme*/) {}
 
   // Show a modal dialog and BLOCK until the user dismisses it. Backends
   // run the platform's native modal loop (`runModal` / `MessageBoxW` /

--- a/webview/src/scheme_exchange.h
+++ b/webview/src/scheme_exchange.h
@@ -53,8 +53,9 @@ inline std::vector<std::pair<std::string, std::string>> LaufeyParseFlatHeaders(
       value_end++;
     if (value_end > len)
       break;
-    out.emplace_back(std::string(headers + i, name_end - i),
-                     std::string(headers + value_start, value_end - value_start));
+    out.emplace_back(
+        std::string(headers + i, name_end - i),
+        std::string(headers + value_start, value_end - value_start));
     i = value_end + 1;
   }
   return out;

--- a/webview/src/scheme_exchange.h
+++ b/webview/src/scheme_exchange.h
@@ -1,0 +1,80 @@
+// Copyright 2025 Divy Srivastava. All rights reserved. MIT license.
+
+#ifndef LAUFEY_SCHEME_EXCHANGE_H_
+#define LAUFEY_SCHEME_EXCHANGE_H_
+
+#include <cctype>
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+// The custom standard scheme laufey serves an app over (e.g. "app://...").
+#define LAUFEY_APP_SCHEME "app"
+
+// Abstract, backend-agnostic handle for one in-flight scheme exchange. Each
+// webview backend subclasses this around its native request/response objects
+// (WKURLSchemeTask, WebKitURISchemeRequest, WebView2 deferral, Android
+// InputStream). The RuntimeLoader's scheme_* vtable functions cast the opaque
+// laufey_scheme_exchange_t* to this base and dispatch through the virtuals.
+class SchemeExchangeBase {
+ public:
+  virtual ~SchemeExchangeBase() = default;
+
+  // Pull up to `cap` bytes of the request body. Returns bytes read (>0), 0 at
+  // EOF, or <0 on error.
+  virtual intptr_t ReadRequestBody(uint8_t* buf, size_t cap) = 0;
+
+  // Send the response status + headers (flat name\0value\0... encoding). Once.
+  virtual void Begin(int status, const char* headers, size_t headers_len) = 0;
+
+  // Append response body bytes. Returns bytes accepted, or <0 if the webview
+  // went away.
+  virtual intptr_t WriteResponse(const uint8_t* buf, size_t len) = 0;
+
+  // Complete the response and release this exchange (typically `delete this`).
+  virtual void Finish() = 0;
+};
+
+// Decode the flat name\0value\0...\0 header encoding into pairs.
+inline std::vector<std::pair<std::string, std::string>> LaufeyParseFlatHeaders(
+    const char* headers, size_t len) {
+  std::vector<std::pair<std::string, std::string>> out;
+  size_t i = 0;
+  while (i < len) {
+    size_t name_end = i;
+    while (name_end < len && headers[name_end] != '\0')
+      name_end++;
+    if (name_end >= len)
+      break;
+    size_t value_start = name_end + 1;
+    size_t value_end = value_start;
+    while (value_end < len && headers[value_end] != '\0')
+      value_end++;
+    if (value_end > len)
+      break;
+    out.emplace_back(std::string(headers + i, name_end - i),
+                     std::string(headers + value_start, value_end - value_start));
+    i = value_end + 1;
+  }
+  return out;
+}
+
+// Encode header pairs into the flat name\0value\0...\0 wire format, lowercasing
+// names. Used to hand a native request's headers to the runtime.
+inline std::string LaufeyFlattenHeaders(
+    const std::vector<std::pair<std::string, std::string>>& headers) {
+  std::string out;
+  for (const auto& [name, value] : headers) {
+    std::string lname = name;
+    for (auto& c : lname)
+      c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+    out.append(lname);
+    out.push_back('\0');
+    out.append(value);
+    out.push_back('\0');
+  }
+  return out;
+}
+
+#endif  // LAUFEY_SCHEME_EXCHANGE_H_

--- a/webview/src/webview_linux.cc
+++ b/webview/src/webview_linux.cc
@@ -1154,7 +1154,9 @@ class LinuxSchemeExchange : public SchemeExchangeBase {
   }
 
   // WebKitURISchemeRequest does not expose the request body.
-  intptr_t ReadRequestBody(uint8_t*, size_t) override { return 0; }
+  intptr_t ReadRequestBody(uint8_t*, size_t) override {
+    return 0;
+  }
 
   void Begin(int status, const char* headers, size_t headers_len) override {
     int fds[2];

--- a/webview/src/webview_linux.cc
+++ b/webview/src/webview_linux.cc
@@ -9,6 +9,12 @@
 #include "init_script.h"
 #include <webkit2/webkit2.h>
 #include <JavaScriptCore/JavaScript.h>
+#include <gio/gunixinputstream.h>
+
+#include <errno.h>
+#include <unistd.h>
+
+#include <atomic>
 
 #include <iostream>
 #include <map>
@@ -332,6 +338,8 @@ class WebKitGTKBackend : public LaufeyBackend {
                        laufey::ValuePtr error) override;
 
   void Run() override;
+
+  void RegisterSchemeHandler(const std::string& scheme) override;
 
   void SetApplicationMenu(uint32_t window_id, laufey_value_t* menu_template,
                           const laufey_backend_api_t* api,
@@ -1121,6 +1129,155 @@ uint32_t WebKitGTKBackend::ShowNotification(
 
 void WebKitGTKBackend::CloseNotification(uint32_t notification_id) {
   laufey_common::CloseNotificationLinux(notification_id);
+}
+
+// ============================================================================
+// Custom app:// scheme handling (in-process transport)
+// ============================================================================
+
+namespace {
+
+// Exchange wrapping a WebKitURISchemeRequest. The response is streamed through
+// a pipe: a GInputStream over the read end is handed to WebKit (on the GTK main
+// thread), and the runtime writes the body to the write end. WebKit reads the
+// stream as bytes arrive; closing the write end signals EOF.
+class LinuxSchemeExchange : public SchemeExchangeBase {
+ public:
+  explicit LinuxSchemeExchange(WebKitURISchemeRequest* request)
+      : request_(WEBKIT_URI_SCHEME_REQUEST(g_object_ref(request))) {}
+
+  ~LinuxSchemeExchange() override {
+    if (write_fd_ >= 0)
+      close(write_fd_);
+    if (request_)
+      g_object_unref(request_);
+  }
+
+  // WebKitURISchemeRequest does not expose the request body.
+  intptr_t ReadRequestBody(uint8_t*, size_t) override { return 0; }
+
+  void Begin(int status, const char* headers, size_t headers_len) override {
+    int fds[2];
+    if (pipe(fds) != 0) {
+      failed_.store(true);
+      return;
+    }
+    read_fd_ = fds[0];
+    write_fd_ = fds[1];
+    auto* d = new BeginData;
+    d->request = WEBKIT_URI_SCHEME_REQUEST(g_object_ref(request_));
+    d->read_fd = read_fd_;
+    d->status = status;
+    d->headers = LaufeyParseFlatHeaders(headers, headers_len);
+    g_idle_add(BeginOnMain, d);
+  }
+
+  intptr_t WriteResponse(const uint8_t* buf, size_t len) override {
+    if (write_fd_ < 0 || failed_.load())
+      return -1;
+    size_t off = 0;
+    while (off < len) {
+      ssize_t n = write(write_fd_, buf + off, len - off);
+      if (n < 0) {
+        if (errno == EINTR)
+          continue;
+        failed_.store(true);
+        return -1;  // EPIPE: the webview went away
+      }
+      off += static_cast<size_t>(n);
+    }
+    return static_cast<intptr_t>(len);
+  }
+
+  void Finish() override {
+    if (write_fd_ >= 0) {
+      close(write_fd_);  // EOF for the GInputStream
+      write_fd_ = -1;
+    }
+    delete this;
+  }
+
+ private:
+  struct BeginData {
+    WebKitURISchemeRequest* request;
+    int read_fd;
+    int status;
+    std::vector<std::pair<std::string, std::string>> headers;
+  };
+
+  static gboolean BeginOnMain(gpointer data) {
+    auto* d = static_cast<BeginData*>(data);
+    GInputStream* stream = g_unix_input_stream_new(d->read_fd, TRUE);
+    WebKitURISchemeResponse* resp = webkit_uri_scheme_response_new(stream, -1);
+    webkit_uri_scheme_response_set_status(resp, d->status, nullptr);
+    SoupMessageHeaders* hdrs =
+        soup_message_headers_new(SOUP_MESSAGE_HEADERS_RESPONSE);
+    for (const auto& [k, v] : d->headers) {
+      soup_message_headers_append(hdrs, k.c_str(), v.c_str());
+    }
+    // set_http_headers takes ownership of `hdrs`.
+    webkit_uri_scheme_response_set_http_headers(resp, hdrs);
+    webkit_uri_scheme_request_finish_with_response(d->request, resp);
+    g_object_unref(resp);
+    g_object_unref(stream);
+    g_object_unref(d->request);
+    delete d;
+    return G_SOURCE_REMOVE;
+  }
+
+  WebKitURISchemeRequest* request_;
+  int read_fd_ = -1;
+  int write_fd_ = -1;
+  std::atomic<bool> failed_{false};
+};
+
+void OnAppSchemeRequest(WebKitURISchemeRequest* request, gpointer) {
+  const char* uri = webkit_uri_scheme_request_get_uri(request);
+  const char* method = webkit_uri_scheme_request_get_http_method(request);
+  std::vector<std::pair<std::string, std::string>> headers;
+  SoupMessageHeaders* req_headers =
+      webkit_uri_scheme_request_get_http_headers(request);
+  if (req_headers) {
+    SoupMessageHeadersIter it;
+    soup_message_headers_iter_init(&it, req_headers);
+    const char* name;
+    const char* value;
+    while (soup_message_headers_iter_next(&it, &name, &value)) {
+      headers.emplace_back(name, value);
+    }
+  }
+  std::string flat = LaufeyFlattenHeaders(headers);
+  // window_id is unused by the desktop bridge (it serves a single named
+  // channel), so 0 is fine.
+  auto* exchange = new LinuxSchemeExchange(request);
+  RuntimeLoader::GetInstance()->DispatchSchemeRequest(
+      0, exchange, method ? method : "GET", uri ? uri : "", flat);
+}
+
+}  // namespace
+
+void WebKitGTKBackend::RegisterSchemeHandler(const std::string& scheme) {
+  // Register on the default web context (shared by all webviews). Must run on
+  // the GTK main thread; the runtime calls this from its own thread.
+  char* scheme_dup = g_strdup(scheme.c_str());
+  g_idle_add(
+      [](gpointer data) -> gboolean {
+        char* s = static_cast<char*>(data);
+        static std::atomic<bool> registered{false};
+        bool expected = false;
+        if (registered.compare_exchange_strong(expected, true)) {
+          WebKitWebContext* ctx = webkit_web_context_get_default();
+          webkit_web_context_register_uri_scheme(ctx, s, OnAppSchemeRequest,
+                                                 nullptr, nullptr);
+          WebKitSecurityManager* sm =
+              webkit_web_context_get_security_manager(ctx);
+          webkit_security_manager_register_uri_scheme_as_secure(sm, s);
+          webkit_security_manager_register_uri_scheme_as_cors_enabled(sm, s);
+        }
+        g_free(s);
+        return G_SOURCE_REMOVE;
+      },
+      scheme_dup);
 }
 
 // ============================================================================

--- a/webview/src/webview_macos.mm
+++ b/webview/src/webview_macos.mm
@@ -297,7 +297,9 @@ class MacSchemeExchange : public SchemeExchangeBase {
     });
   }
 
-  void MarkStopped() { stopped_.store(true); }
+  void MarkStopped() {
+    stopped_.store(true);
+  }
 
  private:
   id<WKURLSchemeTask> task_;

--- a/webview/src/webview_macos.mm
+++ b/webview/src/webview_macos.mm
@@ -220,6 +220,138 @@ static void UnregisterNSWindow(NSWindow* win) {
 
 @end
 
+// --- Custom app:// scheme handling (in-process transport) ---
+
+// Exchange wrapping a WKURLSchemeTask. WKURLSchemeTask methods must be invoked
+// on the main thread, so each response step hops there; a `stopped_` flag
+// (set from -stopURLSchemeTask:) prevents messaging an already-cancelled task.
+class MacSchemeExchange : public SchemeExchangeBase {
+ public:
+  MacSchemeExchange(id<WKURLSchemeTask> task, NSData* body)
+      : task_(task), body_(body) {}
+
+  intptr_t ReadRequestBody(uint8_t* buf, size_t cap) override {
+    if (cap == 0 || !body_)
+      return 0;
+    size_t total = body_.length;
+    if (cursor_ >= total)
+      return 0;
+    size_t n = std::min(cap, total - cursor_);
+    memcpy(buf, static_cast<const uint8_t*>(body_.bytes) + cursor_, n);
+    cursor_ += n;
+    return static_cast<intptr_t>(n);
+  }
+
+  void Begin(int status, const char* headers, size_t headers_len) override {
+    auto pairs = LaufeyParseFlatHeaders(headers, headers_len);
+    NSMutableDictionary* hdr = [NSMutableDictionary dictionary];
+    for (const auto& [k, v] : pairs)
+      hdr[@(k.c_str())] = @(v.c_str());
+    NSURL* url = task_.request.URL;
+    id<WKURLSchemeTask> task = task_;
+    std::atomic<bool>* stopped = &stopped_;
+    dispatch_async(dispatch_get_main_queue(), ^{
+      if (stopped->load())
+        return;
+      NSHTTPURLResponse* resp =
+          [[NSHTTPURLResponse alloc] initWithURL:url
+                                      statusCode:status
+                                     HTTPVersion:@"HTTP/1.1"
+                                    headerFields:hdr];
+      @try {
+        [task didReceiveResponse:resp];
+      } @catch (...) {
+      }
+    });
+  }
+
+  intptr_t WriteResponse(const uint8_t* buf, size_t len) override {
+    if (stopped_.load())
+      return -1;
+    NSData* data = [NSData dataWithBytes:buf length:len];
+    id<WKURLSchemeTask> task = task_;
+    std::atomic<bool>* stopped = &stopped_;
+    dispatch_async(dispatch_get_main_queue(), ^{
+      if (stopped->load())
+        return;
+      @try {
+        [task didReceiveData:data];
+      } @catch (...) {
+      }
+    });
+    return static_cast<intptr_t>(len);
+  }
+
+  void Finish() override {
+    id<WKURLSchemeTask> task = task_;
+    std::atomic<bool>* stopped = &stopped_;
+    MacSchemeExchange* self = this;
+    dispatch_async(dispatch_get_main_queue(), ^{
+      if (!stopped->load()) {
+        @try {
+          [task didFinish];
+        } @catch (...) {
+        }
+      }
+      delete self;
+    });
+  }
+
+  void MarkStopped() { stopped_.store(true); }
+
+ private:
+  id<WKURLSchemeTask> task_;
+  NSData* body_;
+  size_t cursor_ = 0;
+  std::atomic<bool> stopped_{false};
+};
+
+@interface LaufeyURLSchemeHandler : NSObject <WKURLSchemeHandler>
+@property(nonatomic, assign) uint32_t windowId;
+@end
+
+@implementation LaufeyURLSchemeHandler {
+  std::map<void*, MacSchemeExchange*> _tasks;
+  std::mutex _mutex;
+}
+
+- (void)webView:(WKWebView*)webView
+    startURLSchemeTask:(id<WKURLSchemeTask>)task {
+  NSURLRequest* req = task.request;
+  std::string method =
+      req.HTTPMethod ? std::string(req.HTTPMethod.UTF8String) : "GET";
+  std::string url = req.URL.absoluteString.UTF8String;
+  std::vector<std::pair<std::string, std::string>> headers;
+  NSDictionary<NSString*, NSString*>* fields = req.allHTTPHeaderFields;
+  for (NSString* key in fields) {
+    headers.emplace_back(key.UTF8String, fields[key].UTF8String);
+  }
+  std::string flat = LaufeyFlattenHeaders(headers);
+
+  // Note: WKURLSchemeHandler does not expose the request body for all request
+  // kinds (a long-standing WebKit limitation); HTTPBody is forwarded when
+  // present.
+  MacSchemeExchange* exchange = new MacSchemeExchange(task, req.HTTPBody);
+  {
+    std::lock_guard<std::mutex> lock(_mutex);
+    _tasks[(__bridge void*)task] = exchange;
+  }
+  RuntimeLoader::GetInstance()->DispatchSchemeRequest(self.windowId, exchange,
+                                                      method, url, flat);
+}
+
+- (void)webView:(WKWebView*)webView
+    stopURLSchemeTask:(id<WKURLSchemeTask>)task {
+  std::lock_guard<std::mutex> lock(_mutex);
+  auto it = _tasks.find((__bridge void*)task);
+  if (it != _tasks.end()) {
+    it->second->MarkStopped();
+    _tasks.erase(it);
+  }
+}
+
+@end
+
 @interface LaufeyUIDelegate : NSObject <WKUIDelegate>
 @end
 
@@ -626,6 +758,16 @@ void WKWebViewBackend::CreateWindowEx(uint32_t window_id, int width, int height,
       WKWebViewConfiguration* config = [[WKWebViewConfiguration alloc] init];
       [config.userContentController addScriptMessageHandler:handler
                                                        name:@"laufey"];
+
+      // Install the in-process app:// scheme handler (must be set on the
+      // configuration before the WKWebView is created). Requests are bridged
+      // into the runtime's memory transport; if no runtime handler is
+      // registered the exchange is finished immediately.
+      LaufeyURLSchemeHandler* schemeHandler =
+          [[LaufeyURLSchemeHandler alloc] init];
+      schemeHandler.windowId = window_id;
+      [config setURLSchemeHandler:schemeHandler
+                     forURLScheme:@(LAUFEY_APP_SCHEME)];
 
       std::string initScript =
           BuildInitScript(RuntimeLoader::GetInstance()->GetJsNamespace(),

--- a/webview/src/webview_windows.cc
+++ b/webview/src/webview_windows.cc
@@ -128,8 +128,8 @@ namespace {
 std::wstring SchemeUtf8ToWide(const std::string& s) {
   if (s.empty())
     return std::wstring();
-  int n = MultiByteToWideChar(CP_UTF8, 0, s.c_str(),
-                              static_cast<int>(s.size()), nullptr, 0);
+  int n = MultiByteToWideChar(CP_UTF8, 0, s.c_str(), static_cast<int>(s.size()),
+                              nullptr, 0);
   std::wstring w(n, L'\0');
   MultiByteToWideChar(CP_UTF8, 0, s.c_str(), static_cast<int>(s.size()), &w[0],
                       n);
@@ -151,11 +151,10 @@ std::string SchemeWideToUtf8(LPCWSTR s) {
 // WebResourceResponse is created and the deferral completed on the UI thread.
 class WinSchemeExchange : public SchemeExchangeBase {
  public:
-  WinSchemeExchange(
-      ComPtr<ICoreWebView2Environment> env,
-      ComPtr<ICoreWebView2WebResourceRequestedEventArgs> args,
-      ComPtr<ICoreWebView2Deferral> deferral,
-      std::vector<uint8_t> request_body)
+  WinSchemeExchange(ComPtr<ICoreWebView2Environment> env,
+                    ComPtr<ICoreWebView2WebResourceRequestedEventArgs> args,
+                    ComPtr<ICoreWebView2Deferral> deferral,
+                    std::vector<uint8_t> request_body)
       : env_(std::move(env)),
         args_(std::move(args)),
         deferral_(std::move(deferral)),
@@ -167,7 +166,7 @@ class WinSchemeExchange : public SchemeExchangeBase {
     size_t remaining = request_body_.size() - req_cursor_;
     if (remaining == 0)
       return 0;
-    size_t n = std::min(cap, remaining);
+    size_t n = (std::min)(cap, remaining);
     memcpy(buf, request_body_.data() + req_cursor_, n);
     req_cursor_ += n;
     return static_cast<intptr_t>(n);
@@ -203,8 +202,7 @@ class WinSchemeExchange : public SchemeExchangeBase {
         static_cast<UINT>(response_body_.size())));
     std::wstring headers_w;
     for (const auto& [k, v] : headers_) {
-      headers_w +=
-          SchemeUtf8ToWide(k) + L": " + SchemeUtf8ToWide(v) + L"\r\n";
+      headers_w += SchemeUtf8ToWide(k) + L": " + SchemeUtf8ToWide(v) + L"\r\n";
     }
     ComPtr<ICoreWebView2WebResourceResponse> response;
     if (env_) {
@@ -250,8 +248,7 @@ HRESULT HandleAppResourceRequested(
     ComPtr<ICoreWebView2HttpHeadersCollectionIterator> it;
     if (SUCCEEDED(req_headers->GetIterator(&it)) && it) {
       BOOL has_current = FALSE;
-      while (SUCCEEDED(it->get_HasCurrentHeader(&has_current)) &&
-             has_current) {
+      while (SUCCEEDED(it->get_HasCurrentHeader(&has_current)) && has_current) {
         LPWSTR name = nullptr;
         LPWSTR value = nullptr;
         if (SUCCEEDED(it->GetCurrentHeader(&name, &value))) {
@@ -283,8 +280,7 @@ HRESULT HandleAppResourceRequested(
 
   std::string flat = LaufeyFlattenHeaders(headers);
   // window_id is unused by the desktop bridge (single named channel).
-  auto* exchange =
-      new WinSchemeExchange(env, args, deferral, std::move(body));
+  auto* exchange = new WinSchemeExchange(env, args, deferral, std::move(body));
   RuntimeLoader::GetInstance()->DispatchSchemeRequest(0, exchange, method, url,
                                                       flat);
   return S_OK;
@@ -646,7 +642,7 @@ void WebView2Backend::InitializeWebViewForWindow(uint32_t window_id,
                 hwnd,
                 Callback<
                     ICoreWebView2CreateCoreWebView2ControllerCompletedHandler>(
-                    [this, window_id, hwnd](
+                    [this, window_id, hwnd, env](
                         HRESULT result,
                         ICoreWebView2Controller* controller) -> HRESULT {
                       if (FAILED(result) || !controller) {

--- a/webview/src/webview_windows.cc
+++ b/webview/src/webview_windows.cc
@@ -22,11 +22,15 @@
 
 // WebView2 headers
 #include "WebView2.h"
+#include "WebView2EnvironmentOptions.h"
+
+#include <shlwapi.h>
 
 #include <iostream>
 #include <string>
 #include <map>
 #include <mutex>
+#include <vector>
 
 using namespace Microsoft::WRL;
 
@@ -114,6 +118,179 @@ struct UiTaskData {
   void (*task)(void*);
   void* data;
 };
+
+// ============================================================================
+// Custom app:// scheme handling (in-process transport)
+// ============================================================================
+
+namespace {
+
+std::wstring SchemeUtf8ToWide(const std::string& s) {
+  if (s.empty())
+    return std::wstring();
+  int n = MultiByteToWideChar(CP_UTF8, 0, s.c_str(),
+                              static_cast<int>(s.size()), nullptr, 0);
+  std::wstring w(n, L'\0');
+  MultiByteToWideChar(CP_UTF8, 0, s.c_str(), static_cast<int>(s.size()), &w[0],
+                      n);
+  return w;
+}
+
+std::string SchemeWideToUtf8(LPCWSTR s) {
+  if (!s)
+    return std::string();
+  int n = WideCharToMultiByte(CP_UTF8, 0, s, -1, nullptr, 0, nullptr, nullptr);
+  if (n <= 0)
+    return std::string();
+  std::string out(n - 1, '\0');
+  WideCharToMultiByte(CP_UTF8, 0, s, -1, &out[0], n, nullptr, nullptr);
+  return out;
+}
+
+// Buffered exchange: the response is collected, then a single
+// WebResourceResponse is created and the deferral completed on the UI thread.
+class WinSchemeExchange : public SchemeExchangeBase {
+ public:
+  WinSchemeExchange(
+      ComPtr<ICoreWebView2Environment> env,
+      ComPtr<ICoreWebView2WebResourceRequestedEventArgs> args,
+      ComPtr<ICoreWebView2Deferral> deferral,
+      std::vector<uint8_t> request_body)
+      : env_(std::move(env)),
+        args_(std::move(args)),
+        deferral_(std::move(deferral)),
+        request_body_(std::move(request_body)) {}
+
+  intptr_t ReadRequestBody(uint8_t* buf, size_t cap) override {
+    if (cap == 0)
+      return 0;
+    size_t remaining = request_body_.size() - req_cursor_;
+    if (remaining == 0)
+      return 0;
+    size_t n = std::min(cap, remaining);
+    memcpy(buf, request_body_.data() + req_cursor_, n);
+    req_cursor_ += n;
+    return static_cast<intptr_t>(n);
+  }
+
+  void Begin(int status, const char* headers, size_t headers_len) override {
+    status_ = status;
+    headers_ = LaufeyParseFlatHeaders(headers, headers_len);
+  }
+
+  intptr_t WriteResponse(const uint8_t* buf, size_t len) override {
+    response_body_.insert(response_body_.end(), buf, buf + len);
+    return static_cast<intptr_t>(len);
+  }
+
+  void Finish() override {
+    // WebView2 objects are single-threaded; complete on the UI thread.
+    RuntimeLoader::GetInstance()->GetBackend()->PostUiTask(
+        &WinSchemeExchange::CompleteOnUi, this);
+  }
+
+ private:
+  static void CompleteOnUi(void* data) {
+    auto* self = static_cast<WinSchemeExchange*>(data);
+    self->Complete();
+    delete self;
+  }
+
+  void Complete() {
+    ComPtr<IStream> stream;
+    stream.Attach(SHCreateMemStream(
+        response_body_.empty() ? nullptr : response_body_.data(),
+        static_cast<UINT>(response_body_.size())));
+    std::wstring headers_w;
+    for (const auto& [k, v] : headers_) {
+      headers_w +=
+          SchemeUtf8ToWide(k) + L": " + SchemeUtf8ToWide(v) + L"\r\n";
+    }
+    ComPtr<ICoreWebView2WebResourceResponse> response;
+    if (env_) {
+      env_->CreateWebResourceResponse(stream.Get(), status_, L"OK",
+                                      headers_w.c_str(), &response);
+      if (response)
+        args_->put_Response(response.Get());
+    }
+    deferral_->Complete();
+  }
+
+  ComPtr<ICoreWebView2Environment> env_;
+  ComPtr<ICoreWebView2WebResourceRequestedEventArgs> args_;
+  ComPtr<ICoreWebView2Deferral> deferral_;
+  std::vector<uint8_t> request_body_;
+  size_t req_cursor_ = 0;
+  int status_ = 200;
+  std::vector<std::pair<std::string, std::string>> headers_;
+  std::vector<uint8_t> response_body_;
+};
+
+HRESULT HandleAppResourceRequested(
+    ComPtr<ICoreWebView2Environment> env,
+    ICoreWebView2WebResourceRequestedEventArgs* args) {
+  ComPtr<ICoreWebView2WebResourceRequest> request;
+  if (FAILED(args->get_Request(&request)) || !request)
+    return S_OK;
+
+  LPWSTR uri_raw = nullptr;
+  request->get_Uri(&uri_raw);
+  LPWSTR method_raw = nullptr;
+  request->get_Method(&method_raw);
+  std::string url = SchemeWideToUtf8(uri_raw);
+  std::string method = method_raw ? SchemeWideToUtf8(method_raw) : "GET";
+  if (uri_raw)
+    CoTaskMemFree(uri_raw);
+  if (method_raw)
+    CoTaskMemFree(method_raw);
+
+  std::vector<std::pair<std::string, std::string>> headers;
+  ComPtr<ICoreWebView2HttpRequestHeaders> req_headers;
+  if (SUCCEEDED(request->get_Headers(&req_headers)) && req_headers) {
+    ComPtr<ICoreWebView2HttpHeadersCollectionIterator> it;
+    if (SUCCEEDED(req_headers->GetIterator(&it)) && it) {
+      BOOL has_current = FALSE;
+      while (SUCCEEDED(it->get_HasCurrentHeader(&has_current)) &&
+             has_current) {
+        LPWSTR name = nullptr;
+        LPWSTR value = nullptr;
+        if (SUCCEEDED(it->GetCurrentHeader(&name, &value))) {
+          headers.emplace_back(SchemeWideToUtf8(name), SchemeWideToUtf8(value));
+          if (name)
+            CoTaskMemFree(name);
+          if (value)
+            CoTaskMemFree(value);
+        }
+        BOOL has_next = FALSE;
+        if (FAILED(it->MoveNext(&has_next)) || !has_next)
+          break;
+      }
+    }
+  }
+
+  std::vector<uint8_t> body;
+  ComPtr<IStream> content;
+  if (SUCCEEDED(request->get_Content(&content)) && content) {
+    uint8_t chunk[16 * 1024];
+    ULONG read = 0;
+    while (SUCCEEDED(content->Read(chunk, sizeof(chunk), &read)) && read > 0) {
+      body.insert(body.end(), chunk, chunk + read);
+    }
+  }
+
+  ComPtr<ICoreWebView2Deferral> deferral;
+  args->GetDeferral(&deferral);
+
+  std::string flat = LaufeyFlattenHeaders(headers);
+  // window_id is unused by the desktop bridge (single named channel).
+  auto* exchange =
+      new WinSchemeExchange(env, args, deferral, std::move(body));
+  RuntimeLoader::GetInstance()->DispatchSchemeRequest(0, exchange, method, url,
+                                                      flat);
+  return S_OK;
+}
+
+}  // namespace
 
 // ============================================================================
 // WebView2 Backend
@@ -443,8 +620,20 @@ void WebView2Backend::CreateWindowEx(uint32_t window_id, int width, int height,
 
 void WebView2Backend::InitializeWebViewForWindow(uint32_t window_id,
                                                  HWND hwnd) {
+  // Register "app" as a secure custom scheme so the in-process scheme handler
+  // can serve top-level navigations to app:// like a normal origin.
+  auto options = Make<CoreWebView2EnvironmentOptions>();
+  ComPtr<ICoreWebView2EnvironmentOptions4> options4;
+  if (SUCCEEDED(options.As(&options4)) && options4) {
+    auto appScheme = Make<CoreWebView2CustomSchemeRegistration>(L"app");
+    appScheme->put_TreatAsSecure(TRUE);
+    appScheme->put_HasAuthorityComponent(TRUE);
+    ICoreWebView2CustomSchemeRegistration* registrations[] = {appScheme.Get()};
+    options4->SetCustomSchemeRegistrations(1, registrations);
+  }
+
   CreateCoreWebView2EnvironmentWithOptions(
-      nullptr, nullptr, nullptr,
+      nullptr, nullptr, options.Get(),
       Callback<ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler>(
           [this, window_id, hwnd](HRESULT result,
                                   ICoreWebView2Environment* env) -> HRESULT {
@@ -507,6 +696,27 @@ void WebView2Backend::InitializeWebViewForWindow(uint32_t window_id,
                               })
                               .Get(),
                           nullptr);
+
+                      // In-process app:// scheme: intercept requests and
+                      // bridge them to the runtime's memory transport.
+                      {
+                        ComPtr<ICoreWebView2Environment> envPtr = env;
+                        state->webview->AddWebResourceRequestedFilter(
+                            L"app://*", COREWEBVIEW2_WEB_RESOURCE_CONTEXT_ALL);
+                        EventRegistrationToken schemeToken;
+                        state->webview->add_WebResourceRequested(
+                            Callback<
+                                ICoreWebView2WebResourceRequestedEventHandler>(
+                                [envPtr](
+                                    ICoreWebView2* sender,
+                                    ICoreWebView2WebResourceRequestedEventArgs*
+                                        args) -> HRESULT {
+                                  return HandleAppResourceRequested(envPtr,
+                                                                    args);
+                                })
+                                .Get(),
+                            &schemeToken);
+                      }
 
                       state->webview->add_ScriptDialogOpening(
                           Callback<


### PR DESCRIPTION
## Summary

Adds a **custom URL scheme handler** to the laufey C ABI so an embedder can service webview requests for a registered scheme (e.g. `app://`) entirely **in-process**, with no network socket. This is what the Deno desktop runtime uses to serve an embedded browser over an in-memory byte channel instead of a TCP loopback (companion deno PR).

## C ABI (`capi/include/laufey.h`, API version 25 → 26)

New vtable slots:
- `register_scheme_handler(scheme, handler, on_cancel, user_data)`
- `scheme_request_read_body` (pull request body, streaming)
- `scheme_response_begin` / `scheme_response_write` / `scheme_response_finish` (stream response)

Request/response bodies stream; headers use a flat `name\0value\0…` encoding. Backends predating v26 leave the pointers NULL so a runtime can fall back to a socket transport.

Rust wrapper (`capi/src/lib.rs`): `SchemeExchange`, `SchemeRequest`, `register_scheme_handler`; `LAUFEY_API_VERSION = 26`.

## Backends

| Backend | Mechanism | Status |
|---|---|---|
| CEF | `CefSchemeHandlerFactory` + `CefResourceHandler`; `app://` registered standard/secure/fetch in `OnRegisterCustomSchemes` | implemented |
| WKWebView (macOS) | `WKURLSchemeHandler`, streaming `didReceiveData` | implemented |
| WebKitGTK (Linux) | `register_uri_scheme` + pipe-backed `GInputStream` streaming | implemented |
| WebView2 (Windows) | `WebResourceRequested` filter + custom scheme registration (buffered) | implemented |
| Android | Kotlin/JNI surface | **not yet wired** |

Shared webview plumbing via `SchemeExchangeBase` (`webview/src/scheme_exchange.h`).

## Verification

- `capi` Rust crate **compiles** (`cargo build -p laufey`).
- The native C++ backends are **compile-unverified in this environment** (the `nix build .#cef` / `.#webview` targets sandbox each backend dir without sibling `backend-common`, failing at CMake configure before compilation). They need the full desktop build pipeline / CI to compile-verify.

## Docs

`docs/c-abi.md` documents the scheme handler section + API v26.