### PR TITLE
feat: auto-load co-located runtime library matching executable name

### DIFF
--- a/backend-winit-common/src/lib.rs
+++ b/backend-winit-common/src/lib.rs
@@ -3257,12 +3257,57 @@ pub fn dispatch_close_requested_event(
 
 // --- Runtime loading ---
 
+// Path to a runtime library co-located with the running executable and sharing
+// its base name (e.g. example.exe -> example.dll, ./foo -> foo.so), or None.
+// Lets a renamed single-exe auto-load its runtime without --runtime or a
+// wrapper script.
+fn find_colocated_runtime() -> Option<PathBuf> {
+  let exe = env::current_exe().ok()?;
+  let dir = exe.parent()?;
+  let stem = exe.file_stem()?;
+
+  let ext = if cfg!(target_os = "windows") {
+    "dll"
+  } else if cfg!(target_os = "macos") {
+    "dylib"
+  } else {
+    "so"
+  };
+
+  let candidate = dir.join(stem).with_extension(ext);
+  if candidate.exists() && candidate != exe {
+    return Some(candidate);
+  }
+  None
+}
+
 pub fn find_runtime_library() -> Option<PathBuf> {
+  let mut args = env::args().skip(1);
+  while let Some(arg) = args.next() {
+    if arg == "--runtime" {
+      if let Some(path) = args.next() {
+        let p = PathBuf::from(path);
+        if p.exists() {
+          return Some(p);
+        }
+      }
+    } else if let Some(path) = arg.strip_prefix("--runtime=") {
+      let p = PathBuf::from(path);
+      if p.exists() {
+        return Some(p);
+      }
+    }
+  }
+
   if let Ok(path) = env::var("LAUFEY_RUNTIME_PATH") {
     let p = PathBuf::from(path);
     if p.exists() {
       return Some(p);
     }
+  }
+
+  if let Some(p) = find_colocated_runtime() {
+    return Some(p);
   }
 
   let search_paths = [

--- a/cef/src/main_linux.cc
+++ b/cef/src/main_linux.cc
@@ -673,6 +673,10 @@ int main(int argc, char* argv[]) {
     }
   }
 
+  if (g_runtime_path.empty()) {
+    g_runtime_path = LaufeyFindColocatedRuntime();
+  }
+
   // Check for headless / forked worker mode (skip CEF entirely)
   if (is_forked_worker() || is_cli_worker_command(argc, argv)) {
     return run_headless(g_runtime_path);

--- a/cef/src/main_mac.mm
+++ b/cef/src/main_mac.mm
@@ -221,6 +221,9 @@ static int run_headless(const char* runtimePath) {
     if (envPath) {
       path = envPath;
     }
+    if (path.empty()) {
+      path = LaufeyFindColocatedRuntime();
+    }
   }
 
   if (path.empty()) {
@@ -273,6 +276,22 @@ int main(int argc, char* argv[]) {
       g_runtime_path = argv[i] + 10;
       runtimePathArg = [NSString stringWithUTF8String:argv[i] + 10];
       break;
+    }
+  }
+
+  if (g_runtime_path.empty()) {
+    const char* envPath = getenv("LAUFEY_RUNTIME_PATH");
+    if (envPath) {
+      g_runtime_path = envPath;
+      runtimePathArg = [NSString stringWithUTF8String:envPath];
+    }
+  }
+
+  if (g_runtime_path.empty()) {
+    std::string colocated = LaufeyFindColocatedRuntime();
+    if (!colocated.empty()) {
+      g_runtime_path = colocated;
+      runtimePathArg = [NSString stringWithUTF8String:colocated.c_str()];
     }
   }
 

--- a/cef/src/main_windows.cc
+++ b/cef/src/main_windows.cc
@@ -250,6 +250,10 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
     }
   }
 
+  if (g_runtime_path.empty()) {
+    g_runtime_path = LaufeyFindColocatedRuntime();
+  }
+
   // Check for headless / forked worker mode (skip CEF entirely)
   if (is_forked_worker() || (argv && is_cli_worker_command(argc, argv))) {
     if (argv)

--- a/cef/src/runtime_loader.cc
+++ b/cef/src/runtime_loader.cc
@@ -7,8 +7,13 @@
 
 #ifndef _WIN32
 #include <dlfcn.h>
+#include <unistd.h>
 #else
 #include <windows.h>
+#endif
+
+#ifdef __APPLE__
+#include <mach-o/dyld.h>
 #endif
 
 #include <iostream>
@@ -27,6 +32,80 @@
 #include "include/wrapper/cef_helpers.h"
 
 RuntimeLoader* RuntimeLoader::instance_ = nullptr;
+
+namespace {
+
+// Absolute path of the running executable, or "" if it can't be determined.
+std::string GetExecutablePath() {
+#if defined(_WIN32)
+  std::vector<wchar_t> buf(MAX_PATH);
+  for (;;) {
+    DWORD len = GetModuleFileNameW(nullptr, buf.data(),
+                                   static_cast<DWORD>(buf.size()));
+    if (len == 0)
+      return "";
+    if (len < buf.size()) {
+      int size = WideCharToMultiByte(CP_UTF8, 0, buf.data(), -1, nullptr, 0,
+                                     nullptr, nullptr);
+      if (size <= 0)
+        return "";
+      std::string out(size - 1, '\0');
+      WideCharToMultiByte(CP_UTF8, 0, buf.data(), -1, &out[0], size, nullptr,
+                          nullptr);
+      return out;
+    }
+    buf.resize(buf.size() * 2);  // truncated; grow and retry
+  }
+#elif defined(__APPLE__)
+  uint32_t size = 0;
+  _NSGetExecutablePath(nullptr, &size);  // query required length
+  std::vector<char> buf(size);
+  if (_NSGetExecutablePath(buf.data(), &size) != 0)
+    return "";
+  return std::string(buf.data());
+#else
+  std::vector<char> buf(4096);
+  ssize_t len = readlink("/proc/self/exe", buf.data(), buf.size());
+  if (len <= 0)
+    return "";
+  return std::string(buf.data(), static_cast<size_t>(len));
+#endif
+}
+
+bool PathExists(const std::string& path) {
+#if defined(_WIN32)
+  return GetFileAttributesA(path.c_str()) != INVALID_FILE_ATTRIBUTES;
+#else
+  return access(path.c_str(), F_OK) == 0;
+#endif
+}
+
+}  // namespace
+
+std::string LaufeyFindColocatedRuntime() {
+  std::string exe = GetExecutablePath();
+  if (exe.empty())
+    return "";
+
+  // Strip the extension from the filename component only (keep directory dots).
+  size_t slash = exe.find_last_of("/\\");
+  size_t file_start = (slash == std::string::npos) ? 0 : slash + 1;
+  size_t dot = exe.find_last_of('.');
+  std::string base =
+      (dot != std::string::npos && dot > file_start) ? exe.substr(0, dot) : exe;
+
+#if defined(_WIN32)
+  std::string candidate = base + ".dll";
+#elif defined(__APPLE__)
+  std::string candidate = base + ".dylib";
+#else
+  std::string candidate = base + ".so";
+#endif
+
+  if (PathExists(candidate))
+    return candidate;
+  return "";
+}
 
 #ifdef _WIN32
 void ConfigureWin32WindowAsPanel(void* hwnd_ptr) {

--- a/cef/src/runtime_loader.cc
+++ b/cef/src/runtime_loader.cc
@@ -40,8 +40,8 @@ std::string GetExecutablePath() {
 #if defined(_WIN32)
   std::vector<wchar_t> buf(MAX_PATH);
   for (;;) {
-    DWORD len = GetModuleFileNameW(nullptr, buf.data(),
-                                   static_cast<DWORD>(buf.size()));
+    DWORD len =
+        GetModuleFileNameW(nullptr, buf.data(), static_cast<DWORD>(buf.size()));
     if (len == 0)
       return "";
     if (len < buf.size()) {

--- a/cef/src/runtime_loader.h
+++ b/cef/src/runtime_loader.h
@@ -438,6 +438,12 @@ class RuntimeLoader {
   static RuntimeLoader* instance_;
 };
 
+// Returns the path to a runtime library co-located with the running executable
+// and sharing its base name (e.g. example.exe -> example.dll, ./foo -> foo.so),
+// or "" if none exists. Lets a renamed single-exe auto-load its runtime without
+// a --runtime flag or wrapper script.
+std::string LaufeyFindColocatedRuntime();
+
 // Platform-specific native event monitor hooks.
 // Implemented in the platform-specific file (e.g. runtime_loader_mac.mm).
 void InstallNativeMouseMonitor();

--- a/webview/src/main_linux.cc
+++ b/webview/src/main_linux.cc
@@ -29,6 +29,10 @@ int main(int argc, char* argv[]) {
   }
 
   if (runtimePath.empty()) {
+    runtimePath = LaufeyFindColocatedRuntime();
+  }
+
+  if (runtimePath.empty()) {
     const char* searchPaths[] = {
         "./libruntime.so", "./target/debug/libhello.so",
         "./target/release/libhello.so", "/usr/lib/laufey/libruntime.so",

--- a/webview/src/main_mac.mm
+++ b/webview/src/main_mac.mm
@@ -100,6 +100,10 @@ void EnsureEditMenu(NSMenu* menubar) {
     if (envPath) {
       runtimePath = envPath;
     }
+
+    if (runtimePath.empty()) {
+      runtimePath = LaufeyFindColocatedRuntime();
+    }
   }
 
   if (runtimePath.empty()) {
@@ -164,6 +168,9 @@ static int run_headless(const char* runtimePath) {
     const char* envPath = getenv("LAUFEY_RUNTIME_PATH");
     if (envPath) {
       path = envPath;
+    }
+    if (path.empty()) {
+      path = LaufeyFindColocatedRuntime();
     }
   }
 

--- a/webview/src/main_windows.cc
+++ b/webview/src/main_windows.cc
@@ -42,6 +42,10 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
   }
 
   if (runtimePath.empty()) {
+    runtimePath = LaufeyFindColocatedRuntime();
+  }
+
+  if (runtimePath.empty()) {
     const char* searchPaths[] = {".\\runtime.dll",
                                  ".\\target\\debug\\hello.dll",
                                  ".\\target\\release\\hello.dll"};

--- a/webview/src/runtime_loader.cc
+++ b/webview/src/runtime_loader.cc
@@ -29,8 +29,8 @@ std::string GetExecutablePath() {
 #if defined(_WIN32)
   std::vector<wchar_t> buf(MAX_PATH);
   for (;;) {
-    DWORD len = GetModuleFileNameW(nullptr, buf.data(),
-                                   static_cast<DWORD>(buf.size()));
+    DWORD len =
+        GetModuleFileNameW(nullptr, buf.data(), static_cast<DWORD>(buf.size()));
     if (len == 0)
       return "";
     if (len < buf.size()) {

--- a/webview/src/runtime_loader.cc
+++ b/webview/src/runtime_loader.cc
@@ -4,6 +4,7 @@
 
 #ifndef _WIN32
 #include <dlfcn.h>
+#include <unistd.h>
 #else
 #include <windows.h>
 // windows.h defines CreateWindow as a macro which conflicts with
@@ -11,10 +12,89 @@
 #undef CreateWindow
 #endif
 
+#ifdef __APPLE__
+#include <mach-o/dyld.h>
+#endif
+
 #include <iostream>
 #include <cstring>
+#include <vector>
 
 RuntimeLoader* RuntimeLoader::instance_ = nullptr;
+
+namespace {
+
+// Absolute path of the running executable, or "" if it can't be determined.
+std::string GetExecutablePath() {
+#if defined(_WIN32)
+  std::vector<wchar_t> buf(MAX_PATH);
+  for (;;) {
+    DWORD len = GetModuleFileNameW(nullptr, buf.data(),
+                                   static_cast<DWORD>(buf.size()));
+    if (len == 0)
+      return "";
+    if (len < buf.size()) {
+      int size = WideCharToMultiByte(CP_UTF8, 0, buf.data(), -1, nullptr, 0,
+                                     nullptr, nullptr);
+      if (size <= 0)
+        return "";
+      std::string out(size - 1, '\0');
+      WideCharToMultiByte(CP_UTF8, 0, buf.data(), -1, &out[0], size, nullptr,
+                          nullptr);
+      return out;
+    }
+    buf.resize(buf.size() * 2);  // truncated; grow and retry
+  }
+#elif defined(__APPLE__)
+  uint32_t size = 0;
+  _NSGetExecutablePath(nullptr, &size);  // query required length
+  std::vector<char> buf(size);
+  if (_NSGetExecutablePath(buf.data(), &size) != 0)
+    return "";
+  return std::string(buf.data());
+#else
+  std::vector<char> buf(4096);
+  ssize_t len = readlink("/proc/self/exe", buf.data(), buf.size());
+  if (len <= 0)
+    return "";
+  return std::string(buf.data(), static_cast<size_t>(len));
+#endif
+}
+
+bool PathExists(const std::string& path) {
+#if defined(_WIN32)
+  return GetFileAttributesA(path.c_str()) != INVALID_FILE_ATTRIBUTES;
+#else
+  return access(path.c_str(), F_OK) == 0;
+#endif
+}
+
+}  // namespace
+
+std::string LaufeyFindColocatedRuntime() {
+  std::string exe = GetExecutablePath();
+  if (exe.empty())
+    return "";
+
+  // Strip the extension from the filename component only (keep directory dots).
+  size_t slash = exe.find_last_of("/\\");
+  size_t file_start = (slash == std::string::npos) ? 0 : slash + 1;
+  size_t dot = exe.find_last_of('.');
+  std::string base =
+      (dot != std::string::npos && dot > file_start) ? exe.substr(0, dot) : exe;
+
+#if defined(_WIN32)
+  std::string candidate = base + ".dll";
+#elif defined(__APPLE__)
+  std::string candidate = base + ".dylib";
+#else
+  std::string candidate = base + ".so";
+#endif
+
+  if (PathExists(candidate))
+    return candidate;
+  return "";
+}
 
 static void Backend_Navigate(void* data, uint32_t window_id, const char* url) {
   RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);

--- a/webview/src/runtime_loader.h
+++ b/webview/src/runtime_loader.h
@@ -477,4 +477,10 @@ class LaufeyBackend {
 
 LaufeyBackend* CreateLaufeyBackend();
 
+// Returns the path to a runtime library co-located with the running executable
+// and sharing its base name (e.g. example.exe -> example.dll, ./foo -> foo.so),
+// or "" if none exists. Lets a renamed single-exe auto-load its runtime without
+// a --runtime flag or wrapper script.
+std::string LaufeyFindColocatedRuntime();
+
 #endif  // LAUFEY_RUNTIME_LOADER_H_


### PR DESCRIPTION
Closes #14.

## What

All three backends (webview, CEF, winit) now auto-load a dynamic library co-located with the executable that shares its base name. Rename `laufey_webview` → `myapp`, drop `myapp.dll` / `.so` / `.dylib` next to it — loads automatically. No wrapper script, no `--runtime` flag.

Before, the issue's workaround required a wrapper script:

```bat
@echo off
set DIR=%~dp0
"%DIR%laufey_webview.exe" --runtime "%DIR%example.dll" %*
```

Now `laufey_webview.exe` renamed to `example.exe` next to `example.dll` is enough.

## Resolution priority (each backend)

1. `--runtime` arg
2. `LAUFEY_RUNTIME_PATH` env
3. **co-located `<exe-stem>.<ext>`** (new)
4. existing built-in search paths

## Changes

- `webview/src/runtime_loader.{h,cc}`, `cef/src/runtime_loader.{h,cc}` — new `LaufeyFindColocatedRuntime()` helper. Exe path via `GetModuleFileNameW` / `_NSGetExecutablePath` / `readlink("/proc/self/exe")`; picks `.dll` / `.dylib` / `.so` per platform.
- `webview/src/main_{linux,windows,mac}.{cc,mm}`, `cef/src/main_{linux,windows,mac}.{cc,mm}` — wired in (GUI + macOS headless worker).
- `cef/src/main_mac.mm` — also gained the previously-missing `LAUFEY_RUNTIME_PATH` fallback for the GUI path.
- `backend-winit-common/src/lib.rs` — `find_colocated_runtime()` via `env::current_exe()`; `find_runtime_library()` now also parses `--runtime` / `--runtime=` (winit ignored the flag before).

Edge cases: extension stripped from filename component only (directory dots preserved); co-located candidate skipped if it equals the exe itself.

## Verification

- `cargo build -p laufey-backend-winit-common` ✓
- macOS webview CMake/Ninja build ✓
- Runtime smoke test — copied binary to `myapp`, runtime to `myapp.dylib`, ran with no args/env:

```
Runtime loaded successfully from: /private/tmp/colo_test/myapp.dylib
Runtime started
```

Windows + Linux backends not built locally (no toolchain on the dev box); code is platform-symmetric with the macOS path that built and ran.