### PR TITLE
fix exmaple in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ fn main() {
                 .args
                 .first()
                 .and_then(|v| v.as_string())
-                .unwrap_or("World");
+                .unwrap_or("World")
+                .to_string();
             call.resolve(Value::String(format!("Hello, {name}!")));
         })
         .load("index.html");


### PR DESCRIPTION
fix 
```
cargo r
  Downloaded libloading v0.8.9
  Downloaded glob v0.3.3
  Downloaded cfg-if v1.0.4
  Downloaded bitflags v2.13.0
  Downloaded rustc-hash v2.1.2
  Downloaded either v1.16.0
  Downloaded laufey v0.3.3
  Downloaded quote v1.0.46
  Downloaded pin-project-lite v0.2.17
  Downloaded log v0.4.33
  Downloaded unicode-ident v1.0.24
  Downloaded aho-corasick v1.1.4
  Downloaded proc-macro2 v1.0.106
  Downloaded memchr v2.8.2
  Downloaded itertools v0.13.0
  Downloaded regex v1.12.4
  Downloaded syn v2.0.118
  Downloaded regex-syntax v0.8.11
  Downloaded regex-automata v0.4.14
  Downloaded tokio v1.52.3
  Downloaded 20 crates (3.0MiB) in 0.81s
   Compiling proc-macro2 v1.0.106
   Compiling glob v0.3.3
   Compiling unicode-ident v1.0.24
   Compiling quote v1.0.46
   Compiling libc v0.2.186
   Compiling prettyplease v0.2.37
   Compiling regex-syntax v0.8.11
   Compiling cfg-if v1.0.4
   Compiling memchr v2.8.2
   Compiling minimal-lexical v0.2.1
   Compiling bindgen v0.72.1
   Compiling either v1.16.0
   Compiling libloading v0.8.9
   Compiling bitflags v2.13.0
   Compiling itertools v0.13.0
   Compiling rustc-hash v2.1.2
   Compiling shlex v1.3.0
   Compiling log v0.4.33
   Compiling pin-project-lite v0.2.17
   Compiling tokio v1.52.3
   Compiling clang-sys v1.8.1
   Compiling nom v7.1.3
   Compiling syn v2.0.118
   Compiling regex-automata v0.4.14
   Compiling cexpr v0.6.0
   Compiling regex v1.12.4
   Compiling laufey v0.3.3
   Compiling l v0.1.0 (/home/mrcool/dev/deno/lab/desk/l)
error[E0505]: cannot move out of `call` because it is borrowed
  --> src/main.rs:12:13
   |
 6 |           .bind("greet", |call| {
   |                           ---- binding `call` declared here
 7 |               let name = call
   |  ________________________-
 8 | |                 .args
   | |_____________________- borrow of `call.args` occurs here
...
12 |               call.resolve(Value::String(format!("Hello, {name}!")));
   |               ^^^^ move out of `call` occurs here         ---- borrow later used here

For more information about this error, try `rustc --explain E0505`.
error: could not compile `l` (bin "l") due to 1 previous error
```

Though this fails after with Backend API not initialized , I'm using cargo add not testing on the repo itself, its not clear to me from the docs how do I download and link the  backend