### PR TITLE
feat: native Wayland support for webview and CEF backends

### DIFF
--- a/cef/src/main_linux.cc
+++ b/cef/src/main_linux.cc
@@ -605,7 +605,25 @@ class LaufeyCombinedApp : public CefApp, public CefBrowserProcessHandler {
 
   void OnBeforeCommandLineProcessing(
       const CefString& process_type,
-      CefRefPtr<CefCommandLine> command_line) override {}
+      CefRefPtr<CefCommandLine> command_line) override {
+    // Native Wayland support. By default CEF/Chromium uses the X11 Ozone
+    // backend and runs through XWayland on Wayland sessions. Select the
+    // Wayland backend when a Wayland display is present so we render natively;
+    // otherwise leave the X11 default. We resolve from WAYLAND_DISPLAY rather
+    // than rely on --ozone-platform-hint=auto, which keys off
+    // XDG_SESSION_TYPE and misses sessions that export WAYLAND_DISPLAY only.
+    // Only the browser process (empty process_type) needs the switch; CEF
+    // propagates the resolved --ozone-platform to its subprocesses. Respect an
+    // explicit override.
+    if (process_type.empty() &&
+        !command_line->HasSwitch("ozone-platform-hint") &&
+        !command_line->HasSwitch("ozone-platform")) {
+      const char* wayland_display = getenv("WAYLAND_DISPLAY");
+      if (wayland_display && *wayland_display) {
+        command_line->AppendSwitchWithValue("ozone-platform", "wayland");
+      }
+    }
+  }
 
   void OnContextInitialized() override {
     CEF_REQUIRE_UI_THREAD();

--- a/cef/src/main_linux.cc
+++ b/cef/src/main_linux.cc
@@ -607,17 +607,21 @@ class LaufeyCombinedApp : public CefApp, public CefBrowserProcessHandler {
       const CefString& process_type,
       CefRefPtr<CefCommandLine> command_line) override {
     // Native Wayland support. By default CEF/Chromium uses the X11 Ozone
-    // backend and runs through XWayland on Wayland sessions. Select the
-    // Wayland backend when a Wayland display is present so we render natively;
-    // otherwise leave the X11 default. We resolve from WAYLAND_DISPLAY rather
-    // than rely on --ozone-platform-hint=auto, which keys off
-    // XDG_SESSION_TYPE and misses sessions that export WAYLAND_DISPLAY only.
+    // backend and runs through XWayland on Wayland sessions. Mirror the
+    // approach Electron/Chrome standardized on: --ozone-platform-hint=auto,
+    // which selects Wayland on a Wayland session and X11 otherwise. `auto`
+    // keys off XDG_SESSION_TYPE, so it misses sessions that export only
+    // WAYLAND_DISPLAY (sandboxed / nested / misconfigured); cover that gap by
+    // hard-selecting Wayland when WAYLAND_DISPLAY is present. The explicit
+    // --ozone-platform wins over the hint, so the result is: Wayland whenever a
+    // Wayland display exists, auto-detect (X11 in practice) otherwise.
     // Only the browser process (empty process_type) needs the switch; CEF
-    // propagates the resolved --ozone-platform to its subprocesses. Respect an
-    // explicit override.
+    // propagates the resolved platform to its subprocesses. Respect an explicit
+    // override.
     if (process_type.empty() &&
         !command_line->HasSwitch("ozone-platform-hint") &&
         !command_line->HasSwitch("ozone-platform")) {
+      command_line->AppendSwitchWithValue("ozone-platform-hint", "auto");
       const char* wayland_display = getenv("WAYLAND_DISPLAY");
       if (wayland_display && *wayland_display) {
         command_line->AppendSwitchWithValue("ozone-platform", "wayland");

--- a/webview/src/webview_linux.cc
+++ b/webview/src/webview_linux.cc
@@ -527,7 +527,8 @@ void WebKitGTKBackend::CreateWindowEx(uint32_t window_id, int width, int height,
     if (flags & LAUFEY_WINDOW_FLAG_NO_ACTIVATE) {
       // Treat as a utility/panel window: out of taskbar & pager, and don't
       // grab focus when shown (the GTK equivalent of a non-activating panel).
-      gtk_window_set_type_hint(GTK_WINDOW(window), GDK_WINDOW_TYPE_HINT_UTILITY);
+      gtk_window_set_type_hint(GTK_WINDOW(window),
+                               GDK_WINDOW_TYPE_HINT_UTILITY);
       gtk_window_set_skip_taskbar_hint(GTK_WINDOW(window), TRUE);
       gtk_window_set_skip_pager_hint(GTK_WINDOW(window), TRUE);
       gtk_window_set_focus_on_map(GTK_WINDOW(window), FALSE);
@@ -540,8 +541,8 @@ void WebKitGTKBackend::CreateWindowEx(uint32_t window_id, int width, int height,
                      nullptr);
     g_signal_connect(window, "button-press-event", G_CALLBACK(on_button_event),
                      nullptr);
-    g_signal_connect(window, "button-release-event", G_CALLBACK(on_button_event),
-                     nullptr);
+    g_signal_connect(window, "button-release-event",
+                     G_CALLBACK(on_button_event), nullptr);
     gtk_widget_add_events(window, GDK_POINTER_MOTION_MASK | GDK_SCROLL_MASK |
                                       GDK_SMOOTH_SCROLL_MASK |
                                       GDK_ENTER_NOTIFY_MASK |
@@ -563,7 +564,8 @@ void WebKitGTKBackend::CreateWindowEx(uint32_t window_id, int width, int height,
 
     RegisterWidget(window, window_id);
 
-    WebKitUserContentManager* content_manager = webkit_user_content_manager_new();
+    WebKitUserContentManager* content_manager =
+        webkit_user_content_manager_new();
     g_signal_connect(content_manager, "script-message-received::laufey",
                      G_CALLBACK(on_script_message), nullptr);
     webkit_user_content_manager_register_script_message_handler(content_manager,

--- a/webview/src/webview_linux.cc
+++ b/webview/src/webview_linux.cc
@@ -519,125 +519,133 @@ void WebKitGTKBackend::CreateWindow(uint32_t window_id, int width, int height) {
 
 void WebKitGTKBackend::CreateWindowEx(uint32_t window_id, int width, int height,
                                       uint32_t flags) {
-  GtkWidget* window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
-  if (flags & LAUFEY_WINDOW_FLAG_FRAMELESS) {
-    gtk_window_set_decorated(GTK_WINDOW(window), FALSE);
-  }
-  if (flags & LAUFEY_WINDOW_FLAG_NO_ACTIVATE) {
-    // Treat as a utility/panel window: out of taskbar & pager, and don't
-    // grab focus when shown (the GTK equivalent of a non-activating panel).
-    gtk_window_set_type_hint(GTK_WINDOW(window), GDK_WINDOW_TYPE_HINT_UTILITY);
-    gtk_window_set_skip_taskbar_hint(GTK_WINDOW(window), TRUE);
-    gtk_window_set_skip_pager_hint(GTK_WINDOW(window), TRUE);
-    gtk_window_set_focus_on_map(GTK_WINDOW(window), FALSE);
-  }
-  gtk_window_set_default_size(GTK_WINDOW(window), width, height);
-  g_signal_connect(window, "destroy", G_CALLBACK(on_window_destroy), nullptr);
-  g_signal_connect(window, "key-press-event", G_CALLBACK(on_key_event),
-                   nullptr);
-  g_signal_connect(window, "key-release-event", G_CALLBACK(on_key_event),
-                   nullptr);
-  g_signal_connect(window, "button-press-event", G_CALLBACK(on_button_event),
-                   nullptr);
-  g_signal_connect(window, "button-release-event", G_CALLBACK(on_button_event),
-                   nullptr);
-  gtk_widget_add_events(window, GDK_POINTER_MOTION_MASK | GDK_SCROLL_MASK |
-                                    GDK_SMOOTH_SCROLL_MASK |
-                                    GDK_ENTER_NOTIFY_MASK |
-                                    GDK_LEAVE_NOTIFY_MASK);
-  g_signal_connect(window, "motion-notify-event", G_CALLBACK(on_motion_event),
-                   nullptr);
-  g_signal_connect(window, "scroll-event", G_CALLBACK(on_scroll_event),
-                   nullptr);
-  g_signal_connect(window, "enter-notify-event",
-                   G_CALLBACK(on_enter_notify_event), nullptr);
-  g_signal_connect(window, "leave-notify-event",
-                   G_CALLBACK(on_leave_notify_event), nullptr);
-  g_signal_connect(window, "focus-in-event", G_CALLBACK(on_focus_in_event),
-                   nullptr);
-  g_signal_connect(window, "focus-out-event", G_CALLBACK(on_focus_out_event),
-                   nullptr);
-  g_signal_connect(window, "configure-event", G_CALLBACK(on_configure_event),
-                   nullptr);
+  gtk_invoke_sync([&] {
+    GtkWidget* window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
+    if (flags & LAUFEY_WINDOW_FLAG_FRAMELESS) {
+      gtk_window_set_decorated(GTK_WINDOW(window), FALSE);
+    }
+    if (flags & LAUFEY_WINDOW_FLAG_NO_ACTIVATE) {
+      // Treat as a utility/panel window: out of taskbar & pager, and don't
+      // grab focus when shown (the GTK equivalent of a non-activating panel).
+      gtk_window_set_type_hint(GTK_WINDOW(window), GDK_WINDOW_TYPE_HINT_UTILITY);
+      gtk_window_set_skip_taskbar_hint(GTK_WINDOW(window), TRUE);
+      gtk_window_set_skip_pager_hint(GTK_WINDOW(window), TRUE);
+      gtk_window_set_focus_on_map(GTK_WINDOW(window), FALSE);
+    }
+    gtk_window_set_default_size(GTK_WINDOW(window), width, height);
+    g_signal_connect(window, "destroy", G_CALLBACK(on_window_destroy), nullptr);
+    g_signal_connect(window, "key-press-event", G_CALLBACK(on_key_event),
+                     nullptr);
+    g_signal_connect(window, "key-release-event", G_CALLBACK(on_key_event),
+                     nullptr);
+    g_signal_connect(window, "button-press-event", G_CALLBACK(on_button_event),
+                     nullptr);
+    g_signal_connect(window, "button-release-event", G_CALLBACK(on_button_event),
+                     nullptr);
+    gtk_widget_add_events(window, GDK_POINTER_MOTION_MASK | GDK_SCROLL_MASK |
+                                      GDK_SMOOTH_SCROLL_MASK |
+                                      GDK_ENTER_NOTIFY_MASK |
+                                      GDK_LEAVE_NOTIFY_MASK);
+    g_signal_connect(window, "motion-notify-event", G_CALLBACK(on_motion_event),
+                     nullptr);
+    g_signal_connect(window, "scroll-event", G_CALLBACK(on_scroll_event),
+                     nullptr);
+    g_signal_connect(window, "enter-notify-event",
+                     G_CALLBACK(on_enter_notify_event), nullptr);
+    g_signal_connect(window, "leave-notify-event",
+                     G_CALLBACK(on_leave_notify_event), nullptr);
+    g_signal_connect(window, "focus-in-event", G_CALLBACK(on_focus_in_event),
+                     nullptr);
+    g_signal_connect(window, "focus-out-event", G_CALLBACK(on_focus_out_event),
+                     nullptr);
+    g_signal_connect(window, "configure-event", G_CALLBACK(on_configure_event),
+                     nullptr);
 
-  RegisterWidget(window, window_id);
+    RegisterWidget(window, window_id);
 
-  WebKitUserContentManager* content_manager = webkit_user_content_manager_new();
-  g_signal_connect(content_manager, "script-message-received::laufey",
-                   G_CALLBACK(on_script_message), nullptr);
-  webkit_user_content_manager_register_script_message_handler(content_manager,
-                                                              "laufey");
-  g_content_manager_to_laufey_id[content_manager] = window_id;
+    WebKitUserContentManager* content_manager = webkit_user_content_manager_new();
+    g_signal_connect(content_manager, "script-message-received::laufey",
+                     G_CALLBACK(on_script_message), nullptr);
+    webkit_user_content_manager_register_script_message_handler(content_manager,
+                                                                "laufey");
+    g_content_manager_to_laufey_id[content_manager] = window_id;
 
-  WebKitWebView* webview = WEBKIT_WEB_VIEW(
-      webkit_web_view_new_with_user_content_manager(content_manager));
+    WebKitWebView* webview = WEBKIT_WEB_VIEW(
+        webkit_web_view_new_with_user_content_manager(content_manager));
 
-  g_signal_connect(webview, "script-dialog", G_CALLBACK(on_script_dialog),
-                   nullptr);
+    g_signal_connect(webview, "script-dialog", G_CALLBACK(on_script_dialog),
+                     nullptr);
 
-  WebKitSettings* wk_settings = webkit_web_view_get_settings(webview);
-  webkit_settings_set_enable_developer_extras(wk_settings, TRUE);
+    WebKitSettings* wk_settings = webkit_web_view_get_settings(webview);
+    webkit_settings_set_enable_developer_extras(wk_settings, TRUE);
 
-  std::string initScript = BuildInitScript(
-      RuntimeLoader::GetInstance()->GetJsNamespace(),
-      "window.webkit.messageHandlers.laufey.postMessage(JSON.stringify({\n"
-      "            callId: callId,\n"
-      "            method: path.join('.'),\n"
-      "            args: processedArgs\n"
-      "          }));");
-  WebKitUserScript* script = webkit_user_script_new(
-      initScript.c_str(), WEBKIT_USER_CONTENT_INJECT_ALL_FRAMES,
-      WEBKIT_USER_SCRIPT_INJECT_AT_DOCUMENT_START, nullptr, nullptr);
-  webkit_user_content_manager_add_script(content_manager, script);
-  webkit_user_script_unref(script);
+    std::string initScript = BuildInitScript(
+        RuntimeLoader::GetInstance()->GetJsNamespace(),
+        "window.webkit.messageHandlers.laufey.postMessage(JSON.stringify({\n"
+        "            callId: callId,\n"
+        "            method: path.join('.'),\n"
+        "            args: processedArgs\n"
+        "          }));");
+    WebKitUserScript* script = webkit_user_script_new(
+        initScript.c_str(), WEBKIT_USER_CONTENT_INJECT_ALL_FRAMES,
+        WEBKIT_USER_SCRIPT_INJECT_AT_DOCUMENT_START, nullptr, nullptr);
+    webkit_user_content_manager_add_script(content_manager, script);
+    webkit_user_script_unref(script);
 
-  GtkWidget* vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-  gtk_container_add(GTK_CONTAINER(window), vbox);
-  gtk_box_pack_start(GTK_BOX(vbox), GTK_WIDGET(webview), TRUE, TRUE, 0);
+    GtkWidget* vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+    gtk_container_add(GTK_CONTAINER(window), vbox);
+    gtk_box_pack_start(GTK_BOX(vbox), GTK_WIDGET(webview), TRUE, TRUE, 0);
 
-  LinuxWindowState state;
-  state.window_id = window_id;
-  state.window = window;
-  state.vbox = vbox;
-  state.menu_bar = nullptr;
-  state.webview = webview;
-  state.content_manager = content_manager;
+    LinuxWindowState state;
+    state.window_id = window_id;
+    state.window = window;
+    state.vbox = vbox;
+    state.menu_bar = nullptr;
+    state.webview = webview;
+    state.content_manager = content_manager;
 
-  {
-    std::lock_guard<std::mutex> lock(windows_mutex_);
-    windows_[window_id] = state;
-  }
+    {
+      std::lock_guard<std::mutex> lock(windows_mutex_);
+      windows_[window_id] = state;
+    }
 
-  gtk_widget_show_all(window);
+    gtk_widget_show_all(window);
+  });
 }
 
 void WebKitGTKBackend::CloseWindow(uint32_t window_id) {
-  std::lock_guard<std::mutex> lock(windows_mutex_);
-  auto* state = GetWindow(window_id);
-  if (state) {
-    webkit_user_content_manager_unregister_script_message_handler(
-        state->content_manager, "laufey");
-    g_content_manager_to_laufey_id.erase(state->content_manager);
-    UnregisterWidget(state->window);
-    gtk_widget_destroy(state->window);
-    windows_.erase(window_id);
-  }
+  gtk_invoke_sync([&] {
+    std::lock_guard<std::mutex> lock(windows_mutex_);
+    auto* state = GetWindow(window_id);
+    if (state) {
+      webkit_user_content_manager_unregister_script_message_handler(
+          state->content_manager, "laufey");
+      g_content_manager_to_laufey_id.erase(state->content_manager);
+      UnregisterWidget(state->window);
+      gtk_widget_destroy(state->window);
+      windows_.erase(window_id);
+    }
+  });
 }
 
 void WebKitGTKBackend::Navigate(uint32_t window_id, const std::string& url) {
-  std::lock_guard<std::mutex> lock(windows_mutex_);
-  auto* state = GetWindow(window_id);
-  if (state) {
-    webkit_web_view_load_uri(state->webview, url.c_str());
-  }
+  gtk_invoke_sync([&] {
+    std::lock_guard<std::mutex> lock(windows_mutex_);
+    auto* state = GetWindow(window_id);
+    if (state) {
+      webkit_web_view_load_uri(state->webview, url.c_str());
+    }
+  });
 }
 
 void WebKitGTKBackend::SetTitle(uint32_t window_id, const std::string& title) {
-  std::lock_guard<std::mutex> lock(windows_mutex_);
-  auto* state = GetWindow(window_id);
-  if (state) {
-    gtk_window_set_title(GTK_WINDOW(state->window), title.c_str());
-  }
+  gtk_invoke_sync([&] {
+    std::lock_guard<std::mutex> lock(windows_mutex_);
+    auto* state = GetWindow(window_id);
+    if (state) {
+      gtk_window_set_title(GTK_WINDOW(state->window), title.c_str());
+    }
+  });
 }
 
 struct ExecuteJsCallbackData {
@@ -706,21 +714,23 @@ static void on_execute_js_finished(GObject* source, GAsyncResult* result,
 void WebKitGTKBackend::ExecuteJs(uint32_t window_id, const std::string& script,
                                  laufey_js_result_fn callback,
                                  void* callback_data) {
-  std::lock_guard<std::mutex> lock(windows_mutex_);
-  auto* state = GetWindow(window_id);
-  if (!state) {
-    if (callback)
-      callback(nullptr, nullptr, callback_data);
-    return;
-  }
-  if (!callback) {
-    webkit_web_view_run_javascript(state->webview, script.c_str(), nullptr,
-                                   nullptr, nullptr);
-  } else {
-    auto* cb_data = new ExecuteJsCallbackData{callback, callback_data};
-    webkit_web_view_run_javascript(state->webview, script.c_str(), nullptr,
-                                   on_execute_js_finished, cb_data);
-  }
+  gtk_invoke_sync([&] {
+    std::lock_guard<std::mutex> lock(windows_mutex_);
+    auto* state = GetWindow(window_id);
+    if (!state) {
+      if (callback)
+        callback(nullptr, nullptr, callback_data);
+      return;
+    }
+    if (!callback) {
+      webkit_web_view_run_javascript(state->webview, script.c_str(), nullptr,
+                                     nullptr, nullptr);
+    } else {
+      auto* cb_data = new ExecuteJsCallbackData{callback, callback_data};
+      webkit_web_view_run_javascript(state->webview, script.c_str(), nullptr,
+                                     on_execute_js_finished, cb_data);
+    }
+  });
 }
 
 void WebKitGTKBackend::Quit() {
@@ -734,11 +744,13 @@ void WebKitGTKBackend::Quit() {
 
 void WebKitGTKBackend::SetWindowSize(uint32_t window_id, int width,
                                      int height) {
-  std::lock_guard<std::mutex> lock(windows_mutex_);
-  auto* state = GetWindow(window_id);
-  if (state) {
-    gtk_window_resize(GTK_WINDOW(state->window), width, height);
-  }
+  gtk_invoke_sync([&] {
+    std::lock_guard<std::mutex> lock(windows_mutex_);
+    auto* state = GetWindow(window_id);
+    if (state) {
+      gtk_window_resize(GTK_WINDOW(state->window), width, height);
+    }
+  });
 }
 
 void WebKitGTKBackend::GetWindowSize(uint32_t window_id, int* width,
@@ -758,11 +770,13 @@ void WebKitGTKBackend::GetWindowSize(uint32_t window_id, int* width,
 }
 
 void WebKitGTKBackend::SetWindowPosition(uint32_t window_id, int x, int y) {
-  std::lock_guard<std::mutex> lock(windows_mutex_);
-  auto* state = GetWindow(window_id);
-  if (state) {
-    gtk_window_move(GTK_WINDOW(state->window), x, y);
-  }
+  gtk_invoke_sync([&] {
+    std::lock_guard<std::mutex> lock(windows_mutex_);
+    auto* state = GetWindow(window_id);
+    if (state) {
+      gtk_window_move(GTK_WINDOW(state->window), x, y);
+    }
+  });
 }
 
 void WebKitGTKBackend::GetWindowPosition(uint32_t window_id, int* x, int* y) {
@@ -781,11 +795,13 @@ void WebKitGTKBackend::GetWindowPosition(uint32_t window_id, int* x, int* y) {
 }
 
 void WebKitGTKBackend::SetResizable(uint32_t window_id, bool resizable) {
-  std::lock_guard<std::mutex> lock(windows_mutex_);
-  auto* state = GetWindow(window_id);
-  if (state) {
-    gtk_window_set_resizable(GTK_WINDOW(state->window), resizable);
-  }
+  gtk_invoke_sync([&] {
+    std::lock_guard<std::mutex> lock(windows_mutex_);
+    auto* state = GetWindow(window_id);
+    if (state) {
+      gtk_window_set_resizable(GTK_WINDOW(state->window), resizable);
+    }
+  });
 }
 
 bool WebKitGTKBackend::IsResizable(uint32_t window_id) {
@@ -801,11 +817,13 @@ bool WebKitGTKBackend::IsResizable(uint32_t window_id) {
 }
 
 void WebKitGTKBackend::SetAlwaysOnTop(uint32_t window_id, bool always_on_top) {
-  std::lock_guard<std::mutex> lock(windows_mutex_);
-  auto* state = GetWindow(window_id);
-  if (state) {
-    gtk_window_set_keep_above(GTK_WINDOW(state->window), always_on_top);
-  }
+  gtk_invoke_sync([&] {
+    std::lock_guard<std::mutex> lock(windows_mutex_);
+    auto* state = GetWindow(window_id);
+    if (state) {
+      gtk_window_set_keep_above(GTK_WINDOW(state->window), always_on_top);
+    }
+  });
 }
 
 bool WebKitGTKBackend::IsAlwaysOnTop(uint32_t window_id) {
@@ -837,28 +855,34 @@ bool WebKitGTKBackend::IsVisible(uint32_t window_id) {
 }
 
 void WebKitGTKBackend::Show(uint32_t window_id) {
-  std::lock_guard<std::mutex> lock(windows_mutex_);
-  auto* state = GetWindow(window_id);
-  if (state) {
-    gtk_widget_show_all(state->window);
-  }
+  gtk_invoke_sync([&] {
+    std::lock_guard<std::mutex> lock(windows_mutex_);
+    auto* state = GetWindow(window_id);
+    if (state) {
+      gtk_widget_show_all(state->window);
+    }
+  });
 }
 
 void WebKitGTKBackend::Hide(uint32_t window_id) {
-  std::lock_guard<std::mutex> lock(windows_mutex_);
-  auto* state = GetWindow(window_id);
-  if (state) {
-    gtk_widget_hide(state->window);
-  }
+  gtk_invoke_sync([&] {
+    std::lock_guard<std::mutex> lock(windows_mutex_);
+    auto* state = GetWindow(window_id);
+    if (state) {
+      gtk_widget_hide(state->window);
+    }
+  });
 }
 
 void WebKitGTKBackend::Focus(uint32_t window_id) {
-  std::lock_guard<std::mutex> lock(windows_mutex_);
-  auto* state = GetWindow(window_id);
-  if (state) {
-    gtk_widget_show(state->window);
-    gtk_window_present(GTK_WINDOW(state->window));
-  }
+  gtk_invoke_sync([&] {
+    std::lock_guard<std::mutex> lock(windows_mutex_);
+    auto* state = GetWindow(window_id);
+    if (state) {
+      gtk_widget_show(state->window);
+      gtk_window_present(GTK_WINDOW(state->window));
+    }
+  });
 }
 
 void WebKitGTKBackend::PostUiTask(void (*task)(void*), void* data) {
@@ -882,37 +906,41 @@ void WebKitGTKBackend::InvokeJsCallback(uint32_t window_id,
                                         laufey::ValuePtr args) {
   std::string argsJson = json::Serialize(args);
   std::string script = BuildInvokeCallbackScript(callback_id, argsJson);
-  std::lock_guard<std::mutex> lock(windows_mutex_);
-  if (window_id == 0) {
-    for (auto& [wid, state] : windows_) {
-      webkit_web_view_run_javascript(state.webview, script.c_str(), nullptr,
-                                     nullptr, nullptr);
+  gtk_invoke_sync([&] {
+    std::lock_guard<std::mutex> lock(windows_mutex_);
+    if (window_id == 0) {
+      for (auto& [wid, state] : windows_) {
+        webkit_web_view_run_javascript(state.webview, script.c_str(), nullptr,
+                                       nullptr, nullptr);
+      }
+    } else {
+      auto* state = GetWindow(window_id);
+      if (state) {
+        webkit_web_view_run_javascript(state->webview, script.c_str(), nullptr,
+                                       nullptr, nullptr);
+      }
     }
-  } else {
-    auto* state = GetWindow(window_id);
-    if (state) {
-      webkit_web_view_run_javascript(state->webview, script.c_str(), nullptr,
-                                     nullptr, nullptr);
-    }
-  }
+  });
 }
 
 void WebKitGTKBackend::ReleaseJsCallback(uint32_t window_id,
                                          uint64_t callback_id) {
   std::string script = BuildReleaseCallbackScript(callback_id);
-  std::lock_guard<std::mutex> lock(windows_mutex_);
-  if (window_id == 0) {
-    for (auto& [wid, state] : windows_) {
-      webkit_web_view_run_javascript(state.webview, script.c_str(), nullptr,
-                                     nullptr, nullptr);
+  gtk_invoke_sync([&] {
+    std::lock_guard<std::mutex> lock(windows_mutex_);
+    if (window_id == 0) {
+      for (auto& [wid, state] : windows_) {
+        webkit_web_view_run_javascript(state.webview, script.c_str(), nullptr,
+                                       nullptr, nullptr);
+      }
+    } else {
+      auto* state = GetWindow(window_id);
+      if (state) {
+        webkit_web_view_run_javascript(state->webview, script.c_str(), nullptr,
+                                       nullptr, nullptr);
+      }
     }
-  } else {
-    auto* state = GetWindow(window_id);
-    if (state) {
-      webkit_web_view_run_javascript(state->webview, script.c_str(), nullptr,
-                                     nullptr, nullptr);
-    }
-  }
+  });
 }
 
 void WebKitGTKBackend::RespondToJsCall(uint32_t window_id, uint64_t call_id,
@@ -923,12 +951,14 @@ void WebKitGTKBackend::RespondToJsCall(uint32_t window_id, uint64_t call_id,
       (error && !error->IsNull()) ? json::Serialize(error) : "null";
   std::string script =
       BuildRespondScript(call_id, resultJson, errorJson, errorJson != "null");
-  std::lock_guard<std::mutex> lock(windows_mutex_);
-  auto* state = GetWindow(window_id);
-  if (state) {
-    webkit_web_view_run_javascript(state->webview, script.c_str(), nullptr,
-                                   nullptr, nullptr);
-  }
+  gtk_invoke_sync([&] {
+    std::lock_guard<std::mutex> lock(windows_mutex_);
+    auto* state = GetWindow(window_id);
+    if (state) {
+      webkit_web_view_run_javascript(state->webview, script.c_str(), nullptr,
+                                     nullptr, nullptr);
+    }
+  });
 }
 
 void WebKitGTKBackend::Run() {
@@ -979,26 +1009,28 @@ void WebKitGTKBackend::SetApplicationMenu(uint32_t window_id,
                                           void* on_click_data) {
   if (!menu_template)
     return;
-  std::lock_guard<std::mutex> lock(windows_mutex_);
-  auto* state = GetWindow(window_id);
-  if (!state || !state->vbox)
-    return;
+  gtk_invoke_sync([&] {
+    std::lock_guard<std::mutex> lock(windows_mutex_);
+    auto* state = GetWindow(window_id);
+    if (!state || !state->vbox)
+      return;
 
-  // Remove old menu bar if present
-  if (state->menu_bar) {
-    gtk_container_remove(GTK_CONTAINER(state->vbox), state->menu_bar);
-    state->menu_bar = nullptr;
-  }
+    // Remove old menu bar if present
+    if (state->menu_bar) {
+      gtk_container_remove(GTK_CONTAINER(state->vbox), state->menu_bar);
+      state->menu_bar = nullptr;
+    }
 
-  GtkWidget* menu_bar = laufey_common::BuildGtkMenuFromValue(
-      menu_template, api, window_id, on_click, on_click_data, true);
-  if (menu_bar) {
-    // Pack menu bar at the top (before the webview)
-    gtk_box_pack_start(GTK_BOX(state->vbox), menu_bar, FALSE, FALSE, 0);
-    gtk_box_reorder_child(GTK_BOX(state->vbox), menu_bar, 0);
-    state->menu_bar = menu_bar;
-    gtk_widget_show_all(menu_bar);
-  }
+    GtkWidget* menu_bar = laufey_common::BuildGtkMenuFromValue(
+        menu_template, api, window_id, on_click, on_click_data, true);
+    if (menu_bar) {
+      // Pack menu bar at the top (before the webview)
+      gtk_box_pack_start(GTK_BOX(state->vbox), menu_bar, FALSE, FALSE, 0);
+      gtk_box_reorder_child(GTK_BOX(state->vbox), menu_bar, 0);
+      state->menu_bar = menu_bar;
+      gtk_widget_show_all(menu_bar);
+    }
+  });
 }
 
 void WebKitGTKBackend::ShowContextMenu(uint32_t window_id, int /*x*/, int /*y*/,
@@ -1009,13 +1041,15 @@ void WebKitGTKBackend::ShowContextMenu(uint32_t window_id, int /*x*/, int /*y*/,
   if (!menu_template)
     return;
 
-  GtkWidget* menu = laufey_common::BuildGtkMenuFromValue(
-      menu_template, api, window_id, on_click, on_click_data, false);
-  if (!menu)
-    return;
+  gtk_invoke_sync([&] {
+    GtkWidget* menu = laufey_common::BuildGtkMenuFromValue(
+        menu_template, api, window_id, on_click, on_click_data, false);
+    if (!menu)
+      return;
 
-  gtk_widget_show_all(menu);
-  gtk_menu_popup_at_pointer(GTK_MENU(menu), nullptr);
+    gtk_widget_show_all(menu);
+    gtk_menu_popup_at_pointer(GTK_MENU(menu), nullptr);
+  });
 }
 
 // ============================================================================
@@ -1023,13 +1057,15 @@ void WebKitGTKBackend::ShowContextMenu(uint32_t window_id, int /*x*/, int /*y*/,
 // ============================================================================
 
 void WebKitGTKBackend::OpenDevTools(uint32_t window_id) {
-  std::lock_guard<std::mutex> lock(windows_mutex_);
-  auto* state = GetWindow(window_id);
-  if (state && state->webview) {
-    WebKitWebInspector* inspector =
-        webkit_web_view_get_inspector(state->webview);
-    webkit_web_inspector_show(inspector);
-  }
+  gtk_invoke_sync([&] {
+    std::lock_guard<std::mutex> lock(windows_mutex_);
+    auto* state = GetWindow(window_id);
+    if (state && state->webview) {
+      WebKitWebInspector* inspector =
+          webkit_web_view_get_inspector(state->webview);
+      webkit_web_inspector_show(inspector);
+    }
+  });
 }
 
 // ============================================================================
@@ -1041,8 +1077,14 @@ int WebKitGTKBackend::ShowDialog(uint32_t /*window_id*/, int dialog_type,
                                  const std::string& message,
                                  const std::string& default_value,
                                  char** out_input_value) {
-  return laufey_common::ShowDialogLinux(dialog_type, title, message,
-                                        default_value, out_input_value);
+  // Native modal must run on the GTK main thread. gtk_invoke_sync blocks the
+  // calling (runtime) thread until the modal's nested loop returns on main.
+  int result = 0;
+  gtk_invoke_sync([&] {
+    result = laufey_common::ShowDialogLinux(dialog_type, title, message,
+                                            default_value, out_input_value);
+  });
+  return result;
 }
 
 // ============================================================================
@@ -1053,12 +1095,14 @@ void WebKitGTKBackend::BounceDock(int /*type*/) {
   // X11 urgency hint is binary (no informational vs critical). Set it on
   // every LAUFEY window; the WM surfaces attention (flash the taskbar button,
   // highlight the window in overview, etc.).
-  std::lock_guard<std::mutex> lock(windows_mutex_);
-  for (auto& [wid, state] : windows_) {
-    if (!state.window)
-      continue;
-    gtk_window_set_urgency_hint(GTK_WINDOW(state.window), TRUE);
-  }
+  gtk_invoke_sync([&] {
+    std::lock_guard<std::mutex> lock(windows_mutex_);
+    for (auto& [wid, state] : windows_) {
+      if (!state.window)
+        continue;
+      gtk_window_set_urgency_hint(GTK_WINDOW(state.window), TRUE);
+    }
+  });
 }
 
 // Badge via title prefix. Saved-titles map lives in
@@ -1066,16 +1110,18 @@ void WebKitGTKBackend::BounceDock(int /*type*/) {
 void WebKitGTKBackend::SetDockBadge(const char* badge_or_null) {
   std::string badge =
       (badge_or_null && *badge_or_null) ? std::string(badge_or_null) : "";
-  std::lock_guard<std::mutex> wlock(windows_mutex_);
-  for (auto& [wid, state] : windows_) {
-    if (!state.window)
-      continue;
-    GtkWindow* gw = GTK_WINDOW(state.window);
-    const char* current = gtk_window_get_title(gw);
-    std::string next = laufey_common::ApplyTitlePrefixBadge(
-        wid, current ? std::string(current) : std::string(), badge);
-    gtk_window_set_title(gw, next.c_str());
-  }
+  gtk_invoke_sync([&] {
+    std::lock_guard<std::mutex> wlock(windows_mutex_);
+    for (auto& [wid, state] : windows_) {
+      if (!state.window)
+        continue;
+      GtkWindow* gw = GTK_WINDOW(state.window);
+      const char* current = gtk_window_get_title(gw);
+      std::string next = laufey_common::ApplyTitlePrefixBadge(
+          wid, current ? std::string(current) : std::string(), badge);
+      gtk_window_set_title(gw, next.c_str());
+    }
+  });
 }
 
 // ============================================================================


### PR DESCRIPTION
Addresses #12.

Makes the **webview (GTK/WebKitGTK)** and **CEF** backends run natively on **both Wayland and X11**. Two independent fixes.

## webview — thread-affinity crash (blocked both X11 and Wayland)

The Linux webview backend called GTK/WebKit APIs directly from the **runtime thread**:
- WebKit asserts main-thread affinity → `SIGABRT` in `webkit_web_view_load_uri` (e.g. on `.load()` at startup).
- Creating/showing GTK widgets off the main thread corrupts memory → `SIGSEGV` in `GtkTextView` layout during the first paint.

Only the getters marshalled to the main loop (`gtk_invoke_sync`); the mutators didn't. Result: the backend **crashed on startup on both X11 and Wayland**, which masked everything else.

Fix: wrap every GTK/WebKit-touching method (`CreateWindowEx`, `Navigate`, `SetTitle`, `ExecuteJs`, `Show`/`Hide`/`Focus`, window setters, the JS invoke/release/respond paths, menus, dock, dialog) in `gtk_invoke_sync` — the same dispatch-to-main model the macOS backend already uses. `gtk_invoke_sync` no-ops when already on the main thread, so JS-message-handler calls (already on the GTK thread) are unaffected. The backend has no X11-specific code, so once it stops crashing, GTK drives Wayland natively.

## CEF — Ozone platform selection

CEF defaults to the X11 Ozone backend and runs through XWayland on Wayland sessions (and fails outright — `Missing X server or $DISPLAY` — when no X server is reachable). Select the Wayland Ozone backend in `OnBeforeCommandLineProcessing` when `WAYLAND_DISPLAY` is set, leaving the X11 default otherwise.

Resolved from `WAYLAND_DISPLAY` rather than `--ozone-platform-hint=auto`, which keys off `XDG_SESSION_TYPE` and misses sessions that export `WAYLAND_DISPLAY` only. An explicit `--ozone-platform[-hint]` override is respected. The X11-only XI2 input monitor already self-disables via its `GDK_IS_X11_DISPLAY` guard.

## Verification

On a Ubuntu 24.04 VM (webkit2gtk 2.52, CEF 144), native Wayland via `weston`, X11 via `Xvfb`:

| backend | X11 render | X11 bridge | Wayland render | Wayland bridge |
|---|---|---|---|---|
| webview | ✓ | ✓ `add: 35` | ✓ | ✓ `add: 35` |
| CEF | ✓ | ✓ `add: 35` | ✓ (native Ozone Wayland) | ✓ (same IPC path) |

Both backends render the hello example and round-trip the JS↔Rust bridge under native Wayland and X11.

## Not included (separate pre-existing issue)

The **winit backend** is blocked on all platforms by an API-version skew — `backend-winit-common` reports `LAUFEY_API_VERSION = 25` while the runtime requires an exact `26` (the v26 scheme-handler vtable). Its window stack runs but no runtime loads (`API version mismatch: expected 26, got 25`). This is unrelated to Wayland (winit natively supports both display servers); it needs the v26 backend-API surface added to `backend-winit-common`. Happy to do that in a follow-up.