### PR TITLE
Add iOS backend (WKWebView)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1786,6 +1786,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "ios_hello"
+version = "0.1.0"
+dependencies = [
+ "laufey",
+ "tokio",
+]
+
+[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "winit",
     "backend-winit-common",
     "examples/hello",
+    "examples/ios_hello",
     "examples/binding_test",
     "examples/ddcore",
     "examples/presentation",

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -5,6 +5,7 @@
 - [Architecture](architecture.md)
 - [C ABI](c-abi.md)
 - [Backends](backends.md)
+- [iOS](ios.md)
 - [Window management](window-management.md)
 - [JavaScript interop](javascript-interop.md)
 - [Menus](menus.md)

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -14,7 +14,8 @@ features that a given engine can't express on a given OS (see
 | [Winit](https://github.com/littledivy/laufey/tree/main/winit)     | none          | single        | n/a     | no        |
 
 Platform support is x86_64 + aarch64 on macOS and Linux, x86_64 on Windows.
-Android is not supported.
+There is also an **iOS** backend (UIKit + WKWebView, statically linked) — see
+[iOS](ios.md). Android is not supported.
 
 ## CEF
 

--- a/docs/ios.md
+++ b/docs/ios.md
@@ -25,19 +25,20 @@ The runtime's `laufey_runtime_init` / `_start` / `_shutdown` are resolved at
 Rust-linked app.
 
 - A "window" is a `UIWindow` + root `UIViewController` hosting a `WKWebView`.
-- The JS bridge, value marshalling, and init script are shared verbatim with
-  the desktop WebView backend (`runtime_loader.cc`, `laufey_json.h`,
+- The JS bridge, value marshalling, and init script are shared verbatim with the
+  desktop WebView backend (`runtime_loader.cc`, `laufey_json.h`,
   `init_script.h`).
 - Desktop-only surfaces (menus, tray, dock) are no-ops; iOS doesn't link
   `backend-common`, only its value marshalling.
 
-Sources: [`webview/src/webview_ios.mm`](https://github.com/littledivy/laufey/blob/main/webview/src/webview_ios.mm),
+Sources:
+[`webview/src/webview_ios.mm`](https://github.com/littledivy/laufey/blob/main/webview/src/webview_ios.mm),
 [`webview/src/main_ios.mm`](https://github.com/littledivy/laufey/blob/main/webview/src/main_ios.mm).
 
 ## Build
 
-The iOS backend is wired into the webview CMake build. It needs a laufey
-runtime compiled as a **static lib** for the iOS target (e.g. the
+The iOS backend is wired into the webview CMake build. It needs a laufey runtime
+compiled as a **static lib** for the iOS target (e.g. the
 [`examples/ios_hello`](https://github.com/littledivy/laufey/tree/main/examples/ios_hello)
 runtime):
 

--- a/docs/ios.md
+++ b/docs/ios.md
@@ -1,0 +1,98 @@
+# iOS
+
+laufey has an iOS backend: the C ABI (the same `laufey_backend_api_t` the
+desktop backends implement) on **UIKit + WKWebView**. A laufey runtime drives a
+native iOS app — web UI in a `WKWebView`, talking to native code through the
+usual JS bridge. Verified building, signing, and running on a physical device.
+
+## How it differs from desktop
+
+The desktop model is a **backend executable** that `dlopen`s a **runtime
+dylib**. iOS forbids loading arbitrary dylibs and the OS owns the app lifecycle
+(`UIApplicationMain`), so on iOS the two collapse into **one statically-linked
+app binary**:
+
+```
+MyApp.app/MyApp            ← one signed Mach-O
+├─ UIKit shell             main_ios.mm: UIApplicationMain → UIViewController + WKWebView
+├─ laufey iOS backend      webview_ios.mm: fills laufey_backend_api_t
+└─ laufey runtime          your app (capi), linked as a static lib
+```
+
+The runtime's `laufey_runtime_init` / `_start` / `_shutdown` are resolved at
+**link time** (via `RuntimeLoader::LoadStatic`) instead of `dlopen`. A weak
+`main` in `main_ios.mm` lets the same file serve either a C-linked or a
+Rust-linked app.
+
+- A "window" is a `UIWindow` + root `UIViewController` hosting a `WKWebView`.
+- The JS bridge, value marshalling, and init script are shared verbatim with
+  the desktop WebView backend (`runtime_loader.cc`, `laufey_json.h`,
+  `init_script.h`).
+- Desktop-only surfaces (menus, tray, dock) are no-ops; iOS doesn't link
+  `backend-common`, only its value marshalling.
+
+Sources: [`webview/src/webview_ios.mm`](https://github.com/littledivy/laufey/blob/main/webview/src/webview_ios.mm),
+[`webview/src/main_ios.mm`](https://github.com/littledivy/laufey/blob/main/webview/src/main_ios.mm).
+
+## Build
+
+The iOS backend is wired into the webview CMake build. It needs a laufey
+runtime compiled as a **static lib** for the iOS target (e.g. the
+[`examples/ios_hello`](https://github.com/littledivy/laufey/tree/main/examples/ios_hello)
+runtime):
+
+```sh
+# 1. runtime static lib (device: aarch64-apple-ios; simulator: aarch64-apple-ios-sim)
+cargo build --release -p ios_hello --target aarch64-apple-ios
+
+# 2. iOS app via CMake (point LAUFEY_IOS_RUNTIME_LIB at the static lib)
+cd webview
+cmake -B build-ios -G Ninja \
+  -DCMAKE_SYSTEM_NAME=iOS \
+  -DCMAKE_OSX_ARCHITECTURES=arm64 \
+  -DCMAKE_OSX_SYSROOT=iphoneos \
+  -DCMAKE_OSX_DEPLOYMENT_TARGET=15.0 \
+  -DCMAKE_C_COMPILER="$(xcrun -f clang)" \
+  -DCMAKE_CXX_COMPILER="$(xcrun -f clang++)" \
+  -DLAUFEY_IOS_RUNTIME_LIB="$PWD/../target/aarch64-apple-ios/release/libios_hello.a"
+cmake --build build-ios
+# → build-ios/laufey_webview.app
+```
+
+For the **simulator**, use `-DCMAKE_OSX_SYSROOT=iphonesimulator` and the
+`aarch64-apple-ios-sim` runtime lib; install/launch with
+[`ios/build.sh`](https://github.com/littledivy/laufey/blob/main/ios/build.sh) or
+`xcrun simctl install/launch`.
+
+## Sign + package an `.ipa`
+
+[`ios/package-ipa.sh`](https://github.com/littledivy/laufey/blob/main/ios/package-ipa.sh)
+sets the bundle id to match a provisioning profile's App ID, embeds the profile,
+signs with the profile's entitlements, and zips a `Payload/`:
+
+```sh
+ios/package-ipa.sh webview/build-ios/laufey_webview.app \
+  <bundle-id-matching-profile> \
+  "Apple Distribution: Your Team (TEAMID)" \
+  ~/Library/MobileDevice/Provisioning\ Profiles/<uuid>.mobileprovision \
+  laufey.ipa
+```
+
+The bundle id must match the profile's App ID, and the device must be in the
+profile's provisioned devices (ad-hoc) or the profile must be a distribution
+profile for the App Store.
+
+## Install on a device
+
+```sh
+xcrun devicectl list devices                       # find the device id
+xcrun devicectl device install app --device <id> laufey.ipa
+xcrun devicectl device process launch --device <id> <bundle-id>
+```
+
+## Status
+
+- Verified: CMake build → device binary → signed `.ipa` → install + launch on a
+  physical iPhone, and the same backend on the simulator.
+- Not yet: the iOS backend isn't exercised by CI; App Store submission flow is
+  not automated.

--- a/examples/ios_hello/Cargo.toml
+++ b/examples/ios_hello/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "ios_hello"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+# Static lib: on iOS the runtime is linked into the app binary (no dlopen).
+crate-type = ["staticlib"]
+
+[dependencies]
+laufey = { path = "../../capi" }
+tokio = { version = "1", features = ["rt-multi-thread", "time", "macros"] }

--- a/examples/ios_hello/src/lib.rs
+++ b/examples/ios_hello/src/lib.rs
@@ -20,9 +20,8 @@ fn ios_main() {
           .and_then(|v| v.as_string())
           .unwrap_or("World")
           .to_string();
-        call.resolve(Value::String(format!(
-          "Hello, {name}! — from Rust on iOS"
-        )));
+        call
+          .resolve(Value::String(format!("Hello, {name}! — from Rust on iOS")));
       })
       .bind("add", |call| {
         let a = call.args.first().and_then(|v| v.as_int()).unwrap_or(0);

--- a/examples/ios_hello/src/lib.rs
+++ b/examples/ios_hello/src/lib.rs
@@ -1,0 +1,126 @@
+// A laufey app running on iOS. Same capi as the desktop examples — Window +
+// bind() — but linked statically into an iOS app (see webview/src/main_ios.mm).
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicI64, Ordering};
+
+use laufey::{Value, Window};
+
+static COUNTER: AtomicI64 = AtomicI64::new(0);
+
+fn ios_main() {
+  let rt = tokio::runtime::Runtime::new().unwrap();
+  rt.block_on(async {
+    let _win = Window::new(390, 844)
+      .title("laufey on iOS")
+      .bind("greet", |call| {
+        let name = call
+          .args
+          .first()
+          .and_then(|v| v.as_string())
+          .unwrap_or("World")
+          .to_string();
+        call.resolve(Value::String(format!(
+          "Hello, {name}! — from Rust on iOS"
+        )));
+      })
+      .bind("add", |call| {
+        let a = call.args.first().and_then(|v| v.as_int()).unwrap_or(0);
+        let b = call.args.get(1).and_then(|v| v.as_int()).unwrap_or(0);
+        call.resolve(Value::Int(a + b));
+      })
+      .bind("bump", |call| {
+        let n = COUNTER.fetch_add(1, Ordering::SeqCst) + 1;
+        call.resolve(Value::Int(n as i32));
+      })
+      .bind("platform", |call| {
+        let mut m = HashMap::new();
+        m.insert("runtime".into(), Value::String("laufey".into()));
+        m.insert("language".into(), Value::String("Rust".into()));
+        m.insert("engine".into(), Value::String("WKWebView".into()));
+        m.insert("os".into(), Value::String("iOS".into()));
+        call.resolve(Value::Dict(m));
+      })
+      .load(&page_url());
+
+    laufey::run().await;
+  });
+}
+
+// laufey's `data:text/html,` convention expects percent-encoded HTML (the
+// backend percent-decodes it). Encode everything but alphanumerics so it
+// round-trips exactly regardless of CSS `%`, `#`, emoji, etc.
+fn page_url() -> String {
+  let mut out = String::from("data:text/html,");
+  for b in PAGE.bytes() {
+    if b.is_ascii_alphanumeric() {
+      out.push(b as char);
+    } else {
+      out.push_str(&format!("%{b:02X}"));
+    }
+  }
+  out
+}
+
+const PAGE: &str = r#"<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<style>
+  :root { color-scheme: dark; }
+  html,body { margin:0; height:100%; }
+  body {
+    font-family: -apple-system, system-ui, sans-serif;
+    background: radial-gradient(120% 120% at 50% 0%, #16213e 0%, #0b1020 60%, #06070d 100%);
+    color: #eaf2ff; min-height:100%;
+    padding: max(env(safe-area-inset-top), 30px) 22px 40px;
+    -webkit-user-select: none;
+  }
+  .badge { display:inline-block; font-size:12px; letter-spacing:.18em; text-transform:uppercase;
+    color:#00d4ff; border:1px solid rgba(0,212,255,.4); border-radius:999px; padding:5px 12px; }
+  h1 { font-size:32px; margin:18px 0 4px; font-weight:800; letter-spacing:-.02em; }
+  h1 .on { color:#00d4ff; }
+  p.sub { margin:0 0 24px; color:#9fb3c8; font-size:15px; line-height:1.4; }
+  button {
+    -webkit-appearance:none; appearance:none; width:100%; text-align:left;
+    background:rgba(255,255,255,.04); color:#eaf2ff; border:1px solid rgba(255,255,255,.10);
+    padding:15px 18px; margin:8px 0; border-radius:16px; font-size:16px; font-weight:600;
+    display:flex; align-items:center; gap:12px;
+  }
+  button:active { background:rgba(0,212,255,.14); }
+  button .ic { font-size:11px; color:#00d4ff; }
+  button .arrow { margin-left:auto; color:#5b7088; }
+  #out {
+    margin-top:20px; background:rgba(0,0,0,.35); border:1px solid rgba(255,255,255,.08);
+    border-radius:16px; padding:16px; font:13px ui-monospace, Menlo, monospace; min-height:54px;
+    white-space:pre-wrap; word-break:break-word; color:#aef5d0;
+  }
+</style>
+</head>
+<body>
+  <span class="badge">laufey &middot; iOS</span>
+  <h1>Native <span class="on">iOS</span> backend</h1>
+  <p class="sub">WKWebView UI calling into a Rust laufey runtime, statically linked into the app.</p>
+
+  <button onclick="run('greet', Laufey.greet('iOS'))"><span class="ic">&bull;</span> Laufey.greet("iOS") <span class="arrow">&rsaquo;</span></button>
+  <button onclick="run('add', Laufey.add(20, 22))"><span class="ic">&bull;</span> Laufey.add(20, 22) <span class="arrow">&rsaquo;</span></button>
+  <button onclick="run('bump', Laufey.bump())"><span class="ic">&bull;</span> Laufey.bump() — Rust counter <span class="arrow">&rsaquo;</span></button>
+  <button onclick="run('platform', Laufey.platform())"><span class="ic">&bull;</span> Laufey.platform() <span class="arrow">&rsaquo;</span></button>
+
+  <div id="out">Tap a button — JS calls Rust and back.</div>
+
+<script>
+  const out = document.getElementById('out');
+  async function run(label, p) {
+    try { const v = await p; out.textContent = label + ' -> ' +
+      (typeof v === 'object' ? JSON.stringify(v, null, 2) : v); }
+    catch (e) { out.textContent = 'error: ' + e; }
+  }
+  // Prove the bridge end-to-end on load: JS -> Rust -> JS.
+  setTimeout(() => run('greet', Laufey.greet('iOS')), 500);
+</script>
+</body>
+</html>"#;
+
+laufey::main!(ios_main);

--- a/ios/.gitignore
+++ b/ios/.gitignore
@@ -1,0 +1,5 @@
+build/
+# Cross-repo Deno spikes (need ../../rusty_v8 + deno_core); not part of laufey.
+deno_core_demo/
+laufey_deno/
+vendor/

--- a/ios/Info.plist
+++ b/ios/Info.plist
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleDisplayName</key>
+  <string>laufey</string>
+  <key>CFBundleExecutable</key>
+  <string>laufey</string>
+  <key>CFBundleIdentifier</key>
+  <string>dev.laufey.ios</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>laufey</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>0.1.0</string>
+  <key>CFBundleVersion</key>
+  <string>1</string>
+  <key>LSRequiresIPhoneOS</key>
+  <true/>
+  <key>MinimumOSVersion</key>
+  <string>15.0</string>
+  <key>UIDeviceFamily</key>
+  <array>
+    <integer>1</integer>
+  </array>
+  <key>UILaunchScreen</key>
+  <dict/>
+  <key>UISupportedInterfaceOrientations</key>
+  <array>
+    <string>UIInterfaceOrientationPortrait</string>
+  </array>
+</dict>
+</plist>

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,4 +1,4 @@
-# laufey on iOS (experimental)
+# laufey on iOS
 
 A native iOS backend for laufey: the laufey C ABI on UIKit + WKWebView, so a
 laufey runtime (capi) can drive a native iOS app. Verified on the iOS simulator.

--- a/ios/README.md
+++ b/ios/README.md
@@ -35,10 +35,10 @@ to the bound Rust handler.
 
 ## Notes / status
 
-- Simulator-verified; device builds (signing, `.ipa` packaging) are not wired
-  up here yet.
-- The backend is built via the standalone `build.sh` (direct `clang++`), not
-  yet wired into the CMake build used by the desktop backends.
+- Simulator-verified; device builds (signing, `.ipa` packaging) are not wired up
+  here yet.
+- The backend is built via the standalone `build.sh` (direct `clang++`), not yet
+  wired into the CMake build used by the desktop backends.
 - Running the **Deno** desktop runtime on iOS (instead of the lightweight
   `ios_hello` capi runtime) is a separate work-in-progress and is not part of
   this directory.

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,0 +1,44 @@
+# laufey on iOS (experimental)
+
+A native iOS backend for laufey: the laufey C ABI on UIKit + WKWebView, so a
+laufey runtime (capi) can drive a native iOS app. Verified on the iOS simulator.
+
+## Pieces
+
+- `../webview/src/webview_ios.mm` — `WKWebViewIOSBackend : LaufeyBackend`, the
+  same backend seam `WKWebViewBackend` implements on macOS, ported to UIKit: a
+  "window" is a `UIWindow` + root `UIViewController` hosting a `WKWebView`. The
+  JS<->native bridge, value marshalling, and init script are shared with the
+  desktop backends (`runtime_loader.cc` / `laufey_json.h` / `init_script.h`).
+- `../webview/src/main_ios.mm` — `UIApplicationMain` entry. iOS forbids loading
+  arbitrary dylibs, so the runtime is **statically linked** and
+  `laufey_runtime_init/start` are called directly via
+  `RuntimeLoader::LoadStatic` (no dlopen).
+- `../examples/ios_hello` — a laufey app (capi `Window` + `bind`) built as a
+  static lib and linked into the app.
+- `build.sh` — compile the backend, link the runtime static lib, assemble
+  `laufey.app`, install + launch on the booted simulator.
+
+## Build + run on the simulator
+
+```sh
+# 1. runtime static lib
+LIBRARY_PATH="$(xcrun --sdk macosx --show-sdk-path)/usr/lib" \
+  cargo build --release -p ios_hello --target aarch64-apple-ios-sim
+# 2. backend + app bundle + launch (boots a simulator if needed)
+bash ios/build.sh
+```
+
+The JS<->native bridge is the same as desktop: page JS calls
+`Laufey.<method>(...)` (the namespace is set by the runtime), which round-trips
+to the bound Rust handler.
+
+## Notes / status
+
+- Simulator-verified; device builds (signing, `.ipa` packaging) are not wired
+  up here yet.
+- The backend is built via the standalone `build.sh` (direct `clang++`), not
+  yet wired into the CMake build used by the desktop backends.
+- Running the **Deno** desktop runtime on iOS (instead of the lightweight
+  `ios_hello` capi runtime) is a separate work-in-progress and is not part of
+  this directory.

--- a/ios/build.sh
+++ b/ios/build.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Build + run the laufey iOS demo on the booted simulator.
+#   1. compile the C++/ObjC++ iOS backend
+#   2. link with the statically-linked laufey runtime (libios_hello.a)
+#   3. assemble a .app bundle, install + launch on the sim
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+TRIPLE="arm64-apple-ios15.0-simulator"
+SDK="$(xcrun --sdk iphonesimulator --show-sdk-path)"
+CLANGXX="$(xcrun -f clang++)"
+OUT="$ROOT/ios/build"
+APP="$OUT/laufey.app"
+RT="$ROOT/target/aarch64-apple-ios-sim/release/libios_hello.a"
+
+rm -rf "$OUT"; mkdir -p "$APP"
+
+INCS=(-Icapi/include -Iwebview/src -Ibackend-common/include)
+CXXFLAGS=(-target "$TRIPLE" -isysroot "$SDK" -std=c++17 -O2 -fobjc-arc "${INCS[@]}")
+CFLAGS=(-target "$TRIPLE" -isysroot "$SDK" -std=c++17 -O2 "${INCS[@]}")
+
+echo "== compile =="
+"$CLANGXX" "${CFLAGS[@]}"   -c webview/src/runtime_loader.cc        -o "$OUT/runtime_loader.o"
+"$CLANGXX" "${CFLAGS[@]}"   -c backend-common/src/laufey_value.cc   -o "$OUT/laufey_value.o"
+"$CLANGXX" "${CXXFLAGS[@]}" -c webview/src/webview_ios.mm           -o "$OUT/webview_ios.o"
+"$CLANGXX" "${CXXFLAGS[@]}" -c webview/src/main_ios.mm              -o "$OUT/main_ios.o"
+
+echo "== link =="
+"$CLANGXX" -target "$TRIPLE" -isysroot "$SDK" \
+  "$OUT/runtime_loader.o" "$OUT/laufey_value.o" "$OUT/webview_ios.o" "$OUT/main_ios.o" \
+  "$RT" \
+  -lc++ \
+  -framework UIKit -framework WebKit -framework Foundation \
+  -framework Security -framework CoreFoundation -framework SystemConfiguration \
+  -o "$APP/laufey"
+
+cp ios/Info.plist "$APP/Info.plist"
+
+echo "== install + launch =="
+xcrun simctl install booted "$APP"
+xcrun simctl launch --console-pty booted dev.laufey.ios &
+sleep 4
+echo "done"

--- a/ios/package-ipa.sh
+++ b/ios/package-ipa.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Sign a CMake-built iOS .app and package it into an .ipa.
+#
+#   ios/package-ipa.sh <app> <bundle-id> <signing-identity> <provisioning-profile> [out.ipa]
+#
+# Example:
+#   ios/package-ipa.sh webview/build-ios/laufey_webview.app \
+#     com.example.app "Apple Distribution: …" ~/Library/MobileDevice/Provisioning\ Profiles/<uuid>.mobileprovision \
+#     laufey.ipa
+set -euo pipefail
+
+APP="$1"; BUNDLE_ID="$2"; IDENTITY="$3"; PROFILE="$4"; OUT="${5:-app.ipa}"
+WORK="$(mktemp -d)"
+
+# 1. Match the bundle id to the provisioning profile's App ID.
+chmod u+w "$APP/Info.plist"
+/usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier $BUNDLE_ID" "$APP/Info.plist"
+
+# 2. Embed the provisioning profile.
+cp "$PROFILE" "$APP/embedded.mobileprovision"
+
+# 3. Use the profile's entitlements for signing.
+security cms -D -i "$PROFILE" > "$WORK/profile.plist"
+/usr/libexec/PlistBuddy -x -c "Print :Entitlements" "$WORK/profile.plist" > "$WORK/entitlements.plist"
+
+# 4. Sign (deep, with entitlements).
+codesign --force --sign "$IDENTITY" --entitlements "$WORK/entitlements.plist" \
+  --timestamp=none "$APP"
+codesign --verify --verbose "$APP"
+
+# 5. Package Payload/<app> -> .ipa
+rm -rf "$WORK/Payload"; mkdir -p "$WORK/Payload"
+cp -R "$APP" "$WORK/Payload/"
+(cd "$WORK" && zip -qry "$OLDPWD/$OUT" Payload)
+rm -rf "$WORK"
+echo "wrote $OUT"

--- a/webview/CMakeLists.txt
+++ b/webview/CMakeLists.txt
@@ -1,7 +1,11 @@
 cmake_minimum_required(VERSION 3.19)
 project(laufey_webview VERSION 1.0.0 LANGUAGES C CXX)
 
-if(APPLE)
+# Note: CMAKE_SYSTEM_NAME==iOS also has APPLE==TRUE, so detect iOS first.
+if(CMAKE_SYSTEM_NAME STREQUAL "iOS")
+  enable_language(OBJCXX)
+  set(PLATFORM_IOS TRUE)
+elseif(APPLE)
   enable_language(OBJCXX)
   set(PLATFORM_MACOS TRUE)
 elseif(UNIX AND NOT APPLE)
@@ -11,9 +15,13 @@ elseif(WIN32)
 endif()
 
 # Shared native-API implementations (notifications, tray, dock, dialogs, ...).
-# Each platform branch links laufey_backend_common below.
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../backend-common
-                 ${CMAKE_BINARY_DIR}/backend-common)
+# Each platform branch links laufey_backend_common below. iOS doesn't use it
+# (those are desktop-only AppKit/GTK surfaces); it compiles just the value
+# marshalling directly into the target instead.
+if(NOT PLATFORM_IOS)
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../backend-common
+                   ${CMAKE_BINARY_DIR}/backend-common)
+endif()
 
 set(LAUFEY_SRCS_COMMON
   src/webview_value.h
@@ -21,7 +29,14 @@ set(LAUFEY_SRCS_COMMON
   src/runtime_loader.h
 )
 
-if(PLATFORM_MACOS)
+if(PLATFORM_IOS)
+  set(LAUFEY_SRCS_PLATFORM
+    src/webview_ios.mm
+    src/main_ios.mm
+    # iOS doesn't link backend-common; pull in just the value marshalling.
+    ${CMAKE_CURRENT_SOURCE_DIR}/../backend-common/src/laufey_value.cc
+  )
+elseif(PLATFORM_MACOS)
   set(LAUFEY_SRCS_PLATFORM
     src/webview_macos.mm
     src/main_mac.mm
@@ -40,7 +55,54 @@ endif()
 
 set(LAUFEY_TARGET "laufey_webview")
 
-if(PLATFORM_MACOS)
+if(PLATFORM_IOS)
+  # The iOS app links a laufey runtime statically (no dlopen on iOS). Point
+  # this at a runtime static lib, e.g. target/aarch64-apple-ios/release/
+  # libios_hello.a (built from examples/ios_hello).
+  set(LAUFEY_IOS_RUNTIME_LIB "" CACHE FILEPATH "Path to the statically-linked laufey runtime (.a)")
+
+  add_executable(${LAUFEY_TARGET} MACOSX_BUNDLE
+    ${LAUFEY_SRCS_COMMON}
+    ${LAUFEY_SRCS_PLATFORM}
+  )
+
+  find_library(UIKIT_FRAMEWORK UIKit REQUIRED)
+  find_library(WEBKIT_FRAMEWORK WebKit REQUIRED)
+  find_library(FOUNDATION_FRAMEWORK Foundation REQUIRED)
+
+  target_include_directories(${LAUFEY_TARGET} PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../backend-common/include
+  )
+
+  target_link_libraries(${LAUFEY_TARGET}
+    ${UIKIT_FRAMEWORK}
+    ${WEBKIT_FRAMEWORK}
+    ${FOUNDATION_FRAMEWORK}
+    "-lc++"
+  )
+
+  if(LAUFEY_IOS_RUNTIME_LIB)
+    # Force the runtime entry points (referenced only from the C++ shell) to be
+    # pulled from the static lib.
+    target_link_libraries(${LAUFEY_TARGET} "${LAUFEY_IOS_RUNTIME_LIB}")
+    target_link_options(${LAUFEY_TARGET} PRIVATE
+      "-Wl,-u,_laufey_runtime_init"
+      "-Wl,-u,_laufey_runtime_start"
+      "-Wl,-u,_laufey_runtime_shutdown"
+    )
+  endif()
+
+  target_compile_options(${LAUFEY_TARGET} PRIVATE -fobjc-arc)
+
+  set_target_properties(${LAUFEY_TARGET} PROPERTIES
+    MACOSX_BUNDLE_GUI_IDENTIFIER "dev.laufey.ios"
+    MACOSX_BUNDLE_BUNDLE_NAME "laufey"
+    MACOSX_BUNDLE_BUNDLE_VERSION "1.0.0"
+    MACOSX_BUNDLE_SHORT_VERSION_STRING "1.0"
+    XCODE_ATTRIBUTE_TARGETED_DEVICE_FAMILY "1"
+  )
+
+elseif(PLATFORM_MACOS)
   add_executable(${LAUFEY_TARGET} MACOSX_BUNDLE
     ${LAUFEY_SRCS_COMMON}
     ${LAUFEY_SRCS_PLATFORM}

--- a/webview/CMakeLists.txt
+++ b/webview/CMakeLists.txt
@@ -95,6 +95,7 @@ if(PLATFORM_IOS)
   target_compile_options(${LAUFEY_TARGET} PRIVATE -fobjc-arc)
 
   set_target_properties(${LAUFEY_TARGET} PROPERTIES
+    MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/ios/Info.plist.in
     MACOSX_BUNDLE_GUI_IDENTIFIER "dev.laufey.ios"
     MACOSX_BUNDLE_BUNDLE_NAME "laufey"
     MACOSX_BUNDLE_BUNDLE_VERSION "1.0.0"

--- a/webview/ios/Info.plist.in
+++ b/webview/ios/Info.plist.in
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>${MACOSX_BUNDLE_EXECUTABLE_NAME}</string>
+  <key>CFBundleIdentifier</key>
+  <string>${MACOSX_BUNDLE_GUI_IDENTIFIER}</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>${MACOSX_BUNDLE_BUNDLE_NAME}</string>
+  <key>CFBundleDisplayName</key>
+  <string>${MACOSX_BUNDLE_BUNDLE_NAME}</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>${MACOSX_BUNDLE_SHORT_VERSION_STRING}</string>
+  <key>CFBundleVersion</key>
+  <string>${MACOSX_BUNDLE_BUNDLE_VERSION}</string>
+  <key>LSRequiresIPhoneOS</key>
+  <true/>
+  <key>MinimumOSVersion</key>
+  <string>15.0</string>
+  <key>UIDeviceFamily</key>
+  <array>
+    <integer>1</integer>
+  </array>
+  <!-- Without UILaunchScreen iOS runs the app letterboxed (black bars) at a
+       legacy resolution. An empty dict opts into full native screen size. -->
+  <key>UILaunchScreen</key>
+  <dict/>
+  <key>UISupportedInterfaceOrientations</key>
+  <array>
+    <string>UIInterfaceOrientationPortrait</string>
+    <string>UIInterfaceOrientationLandscapeLeft</string>
+    <string>UIInterfaceOrientationLandscapeRight</string>
+  </array>
+  <!-- Allow localhost HTTP (e.g. Deno.serve) and dev content. -->
+  <key>NSAppTransportSecurity</key>
+  <dict>
+    <key>NSAllowsLocalNetworking</key>
+    <true/>
+  </dict>
+</dict>
+</plist>

--- a/webview/src/main_ios.mm
+++ b/webview/src/main_ios.mm
@@ -1,0 +1,56 @@
+// Copyright 2025 Divy Srivastava. All rights reserved. MIT license.
+//
+// iOS app entry for laufey. Unlike the desktop backends (which are an
+// executable that dlopen()s the runtime dylib), iOS forbids loading arbitrary
+// dylibs, so the runtime is *statically linked* into the app binary and its
+// entry points are called directly. UIApplicationMain owns the run loop; the
+// runtime runs on RuntimeLoader's worker thread and creates its UIWindow via
+// the backend (hopping to the main thread).
+
+#import <UIKit/UIKit.h>
+
+#include "runtime_loader.h"
+
+// Provided by the statically-linked laufey runtime (capi `main!` macro).
+extern "C" int laufey_runtime_init(const laufey_backend_api_t* api);
+extern "C" int laufey_runtime_start(void);
+extern "C" void laufey_runtime_shutdown(void);
+
+@interface LaufeyAppDelegate : UIResponder <UIApplicationDelegate>
+@end
+
+@implementation LaufeyAppDelegate
+- (BOOL)application:(UIApplication*)application
+    didFinishLaunchingWithOptions:(NSDictionary*)launchOptions {
+  LaufeyBackend* backend = CreateLaufeyBackend();
+
+  RuntimeLoader* loader = RuntimeLoader::GetInstance();
+  loader->SetBackend(backend);
+  loader->LoadStatic(laufey_runtime_init, laufey_runtime_start,
+                     laufey_runtime_shutdown);
+  // Spawns the runtime thread; the runtime calls create_window, which the
+  // backend builds (and shows) on the main thread.
+  loader->Start();
+  return YES;
+}
+
+- (void)applicationWillTerminate:(UIApplication*)application {
+  RuntimeLoader::GetInstance()->Shutdown();
+}
+@end
+
+// Entry point. Exposed as a plain function so it can be driven either by the
+// weak `main` below (C/C++-linked app, e.g. examples/ios_hello) or by a Rust
+// `main` (the cargo-linked fused build that also embeds deno_core).
+extern "C" int laufey_ios_main(void) {
+  @autoreleasepool {
+    return UIApplicationMain(0, NULL, nil,
+                             NSStringFromClass([LaufeyAppDelegate class]));
+  }
+}
+
+__attribute__((weak)) int main(int argc, char* argv[]) {
+  (void)argc;
+  (void)argv;
+  return laufey_ios_main();
+}

--- a/webview/src/runtime_loader.h
+++ b/webview/src/runtime_loader.h
@@ -30,6 +30,15 @@ class RuntimeLoader {
 
   bool Load(const std::string& path);
 
+  // Static-link path (iOS): the runtime is linked into the app binary, so the
+  // entry points are resolved at link time instead of via dlopen.
+  void LoadStatic(laufey_runtime_init_fn init, laufey_runtime_start_fn start,
+                  laufey_runtime_shutdown_fn shutdown) {
+    init_fn_ = init;
+    start_fn_ = start;
+    shutdown_fn_ = shutdown;
+  }
+
   bool Start();
 
   void Shutdown();

--- a/webview/src/webview_ios.mm
+++ b/webview/src/webview_ios.mm
@@ -187,6 +187,22 @@ void WKWebViewIOSBackend::CreateWindowEx(uint32_t window_id, int width,
           forMainFrameOnly:YES];
       [config.userContentController addUserScript:script];
 
+      // Force a non-zoomable, edge-to-edge viewport (disables pinch / double-
+      // tap zoom regardless of the page's own viewport meta).
+      NSString* noZoom =
+          @"(function(){function f(){var m=document.querySelector("
+          @"'meta[name=viewport]')||document.createElement('meta');"
+          @"m.name='viewport';m.content='width=device-width,initial-scale=1,"
+          @"maximum-scale=1,user-scalable=no,viewport-fit=cover';"
+          @"if(!m.parentNode&&document.head)document.head.appendChild(m);}"
+          @"if(document.head){f();}else{document.addEventListener("
+          @"'DOMContentLoaded',f);}})();";
+      WKUserScript* viewport = [[WKUserScript alloc]
+            initWithSource:noZoom
+             injectionTime:WKUserScriptInjectionTimeAtDocumentStart
+          forMainFrameOnly:YES];
+      [config.userContentController addUserScript:viewport];
+
       // Explicitly enable content JavaScript (iOS may default it off
       // depending on the configuration / loadHTMLString path).
       if (@available(iOS 14.0, *)) {
@@ -206,6 +222,10 @@ void WKWebViewIOSBackend::CreateWindowEx(uint32_t window_id, int width,
       // whole screen instead of being padded under the status bar / home bar.
       webview.scrollView.contentInsetAdjustmentBehavior =
           UIScrollViewContentInsetAdjustmentNever;
+      // No pinch-zoom (app, not a zoomable document).
+      webview.scrollView.minimumZoomScale = 1.0;
+      webview.scrollView.maximumZoomScale = 1.0;
+      webview.scrollView.bouncesZoom = NO;
       if ([webview respondsToSelector:@selector(setInspectable:)]) {
         [webview setInspectable:YES];
       }

--- a/webview/src/webview_ios.mm
+++ b/webview/src/webview_ios.mm
@@ -1,0 +1,315 @@
+// Copyright 2025 Divy Srivastava. All rights reserved. MIT license.
+//
+// iOS / iOS-simulator webview backend for laufey. Implements the LaufeyBackend
+// seam (the same one WKWebViewBackend implements on macOS) on UIKit: a
+// "window" is a UIWindow + root UIViewController hosting a WKWebView. The
+// JS<->native bridge, value marshalling, and init script are all shared with
+// the desktop backends (runtime_loader.cc / laufey_json.h / init_script.h).
+
+#import <UIKit/UIKit.h>
+#import <WebKit/WebKit.h>
+
+#include <map>
+#include <mutex>
+#include <string>
+
+#include "init_script.h"
+#include "laufey_json.h"
+#include "runtime_loader.h"
+
+@class LaufeyIOSMessageHandler;
+
+namespace {
+
+struct IOSWindowState {
+  uint32_t window_id = 0;
+  UIWindow* window = nil;
+  UIViewController* controller = nil;
+  WKWebView* webview = nil;
+  LaufeyIOSMessageHandler* handler = nil;
+};
+
+}  // namespace
+
+// The iOS LaufeyBackend. Most desktop-only surfaces (menus, geometry, dialogs)
+// are inherited no-ops or trivial stubs; the webview + bridge are real.
+class WKWebViewIOSBackend : public LaufeyBackend {
+ public:
+  WKWebViewIOSBackend() = default;
+  ~WKWebViewIOSBackend() override = default;
+
+  void CreateWindow(uint32_t window_id, int width, int height) override {
+    CreateWindowEx(window_id, width, height, 0);
+  }
+  void CreateWindowEx(uint32_t window_id, int width, int height,
+                      uint32_t flags) override;
+  void CloseWindow(uint32_t window_id) override;
+
+  void Navigate(uint32_t window_id, const std::string& url) override;
+  void SetTitle(uint32_t /*window_id*/, const std::string& /*title*/) override {}
+  void ExecuteJs(uint32_t window_id, const std::string& script,
+                 laufey_js_result_fn callback, void* callback_data) override;
+
+  // Window geometry / state — fullscreen on iOS, so these are no-ops/defaults.
+  void SetWindowSize(uint32_t, int, int) override {}
+  void GetWindowSize(uint32_t, int* w, int* h) override {
+    CGRect b = UIScreen.mainScreen.bounds;
+    if (w) *w = (int)b.size.width;
+    if (h) *h = (int)b.size.height;
+  }
+  void SetWindowPosition(uint32_t, int, int) override {}
+  void GetWindowPosition(uint32_t, int* x, int* y) override {
+    if (x) *x = 0;
+    if (y) *y = 0;
+  }
+  void SetResizable(uint32_t, bool) override {}
+  bool IsResizable(uint32_t) override { return false; }
+  void SetAlwaysOnTop(uint32_t, bool) override {}
+  bool IsAlwaysOnTop(uint32_t) override { return false; }
+  bool IsVisible(uint32_t) override { return true; }
+  void Show(uint32_t) override {}
+  void Hide(uint32_t) override {}
+  void Focus(uint32_t) override {}
+
+  void Quit() override {}
+  void PostUiTask(void (*task)(void*), void* data) override {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      task(data);
+    });
+  }
+  void Run() override {}  // UIApplicationMain already owns the run loop.
+
+  void InvokeJsCallback(uint32_t window_id, uint64_t callback_id,
+                        laufey::ValuePtr args) override {
+    EvalOnWindow(window_id,
+                 BuildInvokeCallbackScript(callback_id, json::Serialize(args)));
+  }
+  void ReleaseJsCallback(uint32_t window_id, uint64_t callback_id) override {
+    EvalOnWindow(window_id, BuildReleaseCallbackScript(callback_id));
+  }
+  void RespondToJsCall(uint32_t window_id, uint64_t call_id,
+                       laufey::ValuePtr result, laufey::ValuePtr error) override;
+
+  // Desktop-only UI surfaces: not applicable on iOS.
+  void SetApplicationMenu(uint32_t, laufey_value_t*,
+                          const laufey_backend_api_t*, laufey_menu_click_fn,
+                          void*) override {}
+  void ShowContextMenu(uint32_t, int, int, laufey_value_t*,
+                       const laufey_backend_api_t*, laufey_menu_click_fn,
+                       void*) override {}
+  void OpenDevTools(uint32_t) override {}
+  int ShowDialog(uint32_t, int, const std::string&, const std::string&,
+                 const std::string&, char**) override {
+    return 0;
+  }
+
+  // Called from the script-message handler on the main thread.
+  void HandleJsMessage(uint32_t window_id, uint64_t call_id,
+                       const std::string& method, laufey::ValuePtr args) {
+    RuntimeLoader::GetInstance()->OnJsCall(window_id, call_id, method, args);
+  }
+
+  IOSWindowState* GetWindow(uint32_t window_id) {
+    auto it = windows_.find(window_id);
+    return it == windows_.end() ? nullptr : &it->second;
+  }
+
+ private:
+  void EvalOnWindow(uint32_t window_id, const std::string& script);
+
+  std::map<uint32_t, IOSWindowState> windows_;
+  std::mutex windows_mutex_;
+};
+
+// --- Script message handler: JS -> native -----------------------------------
+
+@interface LaufeyIOSMessageHandler : NSObject <WKScriptMessageHandler>
+@property(nonatomic, assign) WKWebViewIOSBackend* backend;
+@property(nonatomic, assign) uint32_t windowId;
+@end
+
+@implementation LaufeyIOSMessageHandler
+- (void)userContentController:(WKUserContentController*)ucc
+      didReceiveScriptMessage:(WKScriptMessage*)message {
+  if (![message.name isEqualToString:@"laufey"]) return;
+  if (![message.body isKindOfClass:[NSDictionary class]]) return;
+  NSDictionary* body = (NSDictionary*)message.body;
+  NSNumber* callIdNum = body[@"callId"];
+  NSString* method = body[@"method"];
+  id argsJson = body[@"args"];
+  if (!callIdNum || !method) return;
+
+  uint64_t call_id = [callIdNum unsignedLongLongValue];
+  std::string methodStr = [method UTF8String];
+
+  laufey::ValuePtr args = laufey::Value::List();
+  if ([argsJson isKindOfClass:[NSArray class]]) {
+    NSData* jsonData = [NSJSONSerialization dataWithJSONObject:argsJson
+                                                      options:0
+                                                        error:nil];
+    if (jsonData) {
+      NSString* jsonStr = [[NSString alloc] initWithData:jsonData
+                                                encoding:NSUTF8StringEncoding];
+      args = json::ParseJson([jsonStr UTF8String]);
+    }
+  }
+  if (self.backend) {
+    self.backend->HandleJsMessage(self.windowId, call_id, methodStr, args);
+  }
+}
+@end
+
+// --- Backend method implementations -----------------------------------------
+
+void WKWebViewIOSBackend::CreateWindowEx(uint32_t window_id, int width,
+                                         int height, uint32_t /*flags*/) {
+  dispatch_async(dispatch_get_main_queue(), ^{
+    @autoreleasepool {
+      LaufeyIOSMessageHandler* handler =
+          [[LaufeyIOSMessageHandler alloc] init];
+      handler.backend = this;
+      handler.windowId = window_id;
+
+      WKWebViewConfiguration* config = [[WKWebViewConfiguration alloc] init];
+      [config.userContentController addScriptMessageHandler:handler
+                                                       name:@"laufey"];
+
+      std::string initScript =
+          BuildInitScript(RuntimeLoader::GetInstance()->GetJsNamespace(),
+                          "window.webkit.messageHandlers.laufey.postMessage({\n"
+                          "            callId: callId,\n"
+                          "            method: path.join('.'),\n"
+                          "            args: processedArgs\n"
+                          "          });");
+      WKUserScript* script = [[WKUserScript alloc]
+            initWithSource:[NSString stringWithUTF8String:initScript.c_str()]
+             injectionTime:WKUserScriptInjectionTimeAtDocumentStart
+          forMainFrameOnly:YES];
+      [config.userContentController addUserScript:script];
+
+      // Explicitly enable content JavaScript (iOS may default it off
+      // depending on the configuration / loadHTMLString path).
+      if (@available(iOS 14.0, *)) {
+        config.defaultWebpagePreferences.allowsContentJavaScript = YES;
+      }
+      config.preferences.javaScriptEnabled = YES;
+
+      CGRect bounds = UIScreen.mainScreen.bounds;
+      WKWebView* webview = [[WKWebView alloc] initWithFrame:bounds
+                                              configuration:config];
+      webview.autoresizingMask =
+          UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+      if ([webview respondsToSelector:@selector(setInspectable:)]) {
+        [webview setInspectable:YES];
+      }
+
+      UIViewController* vc = [[UIViewController alloc] init];
+      [vc.view addSubview:webview];
+
+      vc.view.backgroundColor = UIColor.blackColor;
+      webview.frame = vc.view.bounds;
+
+      UIWindow* window = [[UIWindow alloc] initWithFrame:bounds];
+      window.rootViewController = vc;
+      [window makeKeyAndVisible];
+
+      IOSWindowState state;
+      state.window_id = window_id;
+      state.window = window;
+      state.controller = vc;
+      state.webview = webview;
+      state.handler = handler;
+      {
+        std::lock_guard<std::mutex> lock(windows_mutex_);
+        windows_[window_id] = state;
+      }
+      (void)width;
+      (void)height;
+    }
+  });
+}
+
+void WKWebViewIOSBackend::CloseWindow(uint32_t window_id) {
+  dispatch_async(dispatch_get_main_queue(), ^{
+    @autoreleasepool {
+      std::lock_guard<std::mutex> lock(windows_mutex_);
+      auto it = windows_.find(window_id);
+      if (it == windows_.end()) return;
+      it->second.window.hidden = YES;
+      windows_.erase(it);
+    }
+  });
+}
+
+void WKWebViewIOSBackend::Navigate(uint32_t window_id, const std::string& url) {
+  std::string urlCopy = url;
+  dispatch_async(dispatch_get_main_queue(), ^{
+    @autoreleasepool {
+      std::lock_guard<std::mutex> lock(windows_mutex_);
+      auto* state = GetWindow(window_id);
+      if (!state) return;
+      if (urlCopy.rfind("data:text/html,", 0) == 0) {
+        NSString* html = [NSString stringWithUTF8String:urlCopy.c_str() + 15];
+        html = [html stringByRemovingPercentEncoding];
+        [state->webview loadHTMLString:html baseURL:nil];
+        return;
+      }
+      NSURL* nsurl =
+          [NSURL URLWithString:[NSString stringWithUTF8String:urlCopy.c_str()]];
+      if (nsurl && nsurl.scheme.length > 0) {
+        [state->webview loadRequest:[NSURLRequest requestWithURL:nsurl]];
+      }
+    }
+  });
+}
+
+void WKWebViewIOSBackend::ExecuteJs(uint32_t window_id,
+                                    const std::string& script,
+                                    laufey_js_result_fn callback,
+                                    void* callback_data) {
+  std::string scriptCopy = script;
+  dispatch_async(dispatch_get_main_queue(), ^{
+    @autoreleasepool {
+      std::lock_guard<std::mutex> lock(windows_mutex_);
+      auto* state = GetWindow(window_id);
+      if (!state) {
+        if (callback) callback(nullptr, nullptr, callback_data);
+        return;
+      }
+      NSString* js = [NSString stringWithUTF8String:scriptCopy.c_str()];
+      [state->webview evaluateJavaScript:js
+                       completionHandler:^(id, NSError*) {
+                         if (callback)
+                           callback(nullptr, nullptr, callback_data);
+                       }];
+    }
+  });
+}
+
+void WKWebViewIOSBackend::RespondToJsCall(uint32_t window_id, uint64_t call_id,
+                                          laufey::ValuePtr result,
+                                          laufey::ValuePtr error) {
+  std::string resultJson = json::Serialize(result);
+  std::string errorJson = error ? json::Serialize(error) : "null";
+  std::string script = BuildRespondScript(call_id, resultJson, errorJson,
+                                          static_cast<bool>(error));
+  EvalOnWindow(window_id, script);
+}
+
+void WKWebViewIOSBackend::EvalOnWindow(uint32_t window_id,
+                                       const std::string& script) {
+  std::string scriptCopy = script;
+  dispatch_async(dispatch_get_main_queue(), ^{
+    @autoreleasepool {
+      std::lock_guard<std::mutex> lock(windows_mutex_);
+      auto* state = GetWindow(window_id);
+      if (!state) return;
+      NSString* js = [NSString stringWithUTF8String:scriptCopy.c_str()];
+      [state->webview evaluateJavaScript:js completionHandler:nil];
+    }
+  });
+}
+
+LaufeyBackend* CreateLaufeyBackend() {
+  return new WKWebViewIOSBackend();
+}

--- a/webview/src/webview_ios.mm
+++ b/webview/src/webview_ios.mm
@@ -197,17 +197,31 @@ void WKWebViewIOSBackend::CreateWindowEx(uint32_t window_id, int width,
       CGRect bounds = UIScreen.mainScreen.bounds;
       WKWebView* webview = [[WKWebView alloc] initWithFrame:bounds
                                               configuration:config];
-      webview.autoresizingMask =
-          UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+      webview.translatesAutoresizingMaskIntoConstraints = NO;
+      webview.opaque = NO;
+      webview.backgroundColor = UIColor.blackColor;
+      // Edge-to-edge: stop the scroll view from insetting content for the
+      // safe area (the page handles insets via viewport-fit=cover +
+      // env(safe-area-inset-*)). This is what makes the web content fill the
+      // whole screen instead of being padded under the status bar / home bar.
+      webview.scrollView.contentInsetAdjustmentBehavior =
+          UIScrollViewContentInsetAdjustmentNever;
       if ([webview respondsToSelector:@selector(setInspectable:)]) {
         [webview setInspectable:YES];
       }
 
       UIViewController* vc = [[UIViewController alloc] init];
+      vc.view.backgroundColor = UIColor.blackColor;
       [vc.view addSubview:webview];
 
-      vc.view.backgroundColor = UIColor.blackColor;
-      webview.frame = vc.view.bounds;
+      // Pin to the view's full bounds (not the safe area) so the webview is
+      // truly full-screen; autoresizing alone left a one-shot frame.
+      [NSLayoutConstraint activateConstraints:@[
+        [webview.topAnchor constraintEqualToAnchor:vc.view.topAnchor],
+        [webview.bottomAnchor constraintEqualToAnchor:vc.view.bottomAnchor],
+        [webview.leadingAnchor constraintEqualToAnchor:vc.view.leadingAnchor],
+        [webview.trailingAnchor constraintEqualToAnchor:vc.view.trailingAnchor],
+      ]];
 
       UIWindow* window = [[UIWindow alloc] initWithFrame:bounds];
       window.rootViewController = vc;

--- a/webview/src/webview_ios.mm
+++ b/webview/src/webview_ios.mm
@@ -46,7 +46,8 @@ class WKWebViewIOSBackend : public LaufeyBackend {
   void CloseWindow(uint32_t window_id) override;
 
   void Navigate(uint32_t window_id, const std::string& url) override;
-  void SetTitle(uint32_t /*window_id*/, const std::string& /*title*/) override {}
+  void SetTitle(uint32_t /*window_id*/, const std::string& /*title*/) override {
+  }
   void ExecuteJs(uint32_t window_id, const std::string& script,
                  laufey_js_result_fn callback, void* callback_data) override;
 
@@ -54,19 +55,29 @@ class WKWebViewIOSBackend : public LaufeyBackend {
   void SetWindowSize(uint32_t, int, int) override {}
   void GetWindowSize(uint32_t, int* w, int* h) override {
     CGRect b = UIScreen.mainScreen.bounds;
-    if (w) *w = (int)b.size.width;
-    if (h) *h = (int)b.size.height;
+    if (w)
+      *w = (int)b.size.width;
+    if (h)
+      *h = (int)b.size.height;
   }
   void SetWindowPosition(uint32_t, int, int) override {}
   void GetWindowPosition(uint32_t, int* x, int* y) override {
-    if (x) *x = 0;
-    if (y) *y = 0;
+    if (x)
+      *x = 0;
+    if (y)
+      *y = 0;
   }
   void SetResizable(uint32_t, bool) override {}
-  bool IsResizable(uint32_t) override { return false; }
+  bool IsResizable(uint32_t) override {
+    return false;
+  }
   void SetAlwaysOnTop(uint32_t, bool) override {}
-  bool IsAlwaysOnTop(uint32_t) override { return false; }
-  bool IsVisible(uint32_t) override { return true; }
+  bool IsAlwaysOnTop(uint32_t) override {
+    return false;
+  }
+  bool IsVisible(uint32_t) override {
+    return true;
+  }
   void Show(uint32_t) override {}
   void Hide(uint32_t) override {}
   void Focus(uint32_t) override {}
@@ -88,7 +99,8 @@ class WKWebViewIOSBackend : public LaufeyBackend {
     EvalOnWindow(window_id, BuildReleaseCallbackScript(callback_id));
   }
   void RespondToJsCall(uint32_t window_id, uint64_t call_id,
-                       laufey::ValuePtr result, laufey::ValuePtr error) override;
+                       laufey::ValuePtr result,
+                       laufey::ValuePtr error) override;
 
   // Desktop-only UI surfaces: not applicable on iOS.
   void SetApplicationMenu(uint32_t, laufey_value_t*,
@@ -131,13 +143,16 @@ class WKWebViewIOSBackend : public LaufeyBackend {
 @implementation LaufeyIOSMessageHandler
 - (void)userContentController:(WKUserContentController*)ucc
       didReceiveScriptMessage:(WKScriptMessage*)message {
-  if (![message.name isEqualToString:@"laufey"]) return;
-  if (![message.body isKindOfClass:[NSDictionary class]]) return;
+  if (![message.name isEqualToString:@"laufey"])
+    return;
+  if (![message.body isKindOfClass:[NSDictionary class]])
+    return;
   NSDictionary* body = (NSDictionary*)message.body;
   NSNumber* callIdNum = body[@"callId"];
   NSString* method = body[@"method"];
   id argsJson = body[@"args"];
-  if (!callIdNum || !method) return;
+  if (!callIdNum || !method)
+    return;
 
   uint64_t call_id = [callIdNum unsignedLongLongValue];
   std::string methodStr = [method UTF8String];
@@ -145,8 +160,8 @@ class WKWebViewIOSBackend : public LaufeyBackend {
   laufey::ValuePtr args = laufey::Value::List();
   if ([argsJson isKindOfClass:[NSArray class]]) {
     NSData* jsonData = [NSJSONSerialization dataWithJSONObject:argsJson
-                                                      options:0
-                                                        error:nil];
+                                                       options:0
+                                                         error:nil];
     if (jsonData) {
       NSString* jsonStr = [[NSString alloc] initWithData:jsonData
                                                 encoding:NSUTF8StringEncoding];
@@ -165,8 +180,7 @@ void WKWebViewIOSBackend::CreateWindowEx(uint32_t window_id, int width,
                                          int height, uint32_t /*flags*/) {
   dispatch_async(dispatch_get_main_queue(), ^{
     @autoreleasepool {
-      LaufeyIOSMessageHandler* handler =
-          [[LaufeyIOSMessageHandler alloc] init];
+      LaufeyIOSMessageHandler* handler = [[LaufeyIOSMessageHandler alloc] init];
       handler.backend = this;
       handler.windowId = window_id;
 
@@ -268,7 +282,8 @@ void WKWebViewIOSBackend::CloseWindow(uint32_t window_id) {
     @autoreleasepool {
       std::lock_guard<std::mutex> lock(windows_mutex_);
       auto it = windows_.find(window_id);
-      if (it == windows_.end()) return;
+      if (it == windows_.end())
+        return;
       it->second.window.hidden = YES;
       windows_.erase(it);
     }
@@ -281,7 +296,8 @@ void WKWebViewIOSBackend::Navigate(uint32_t window_id, const std::string& url) {
     @autoreleasepool {
       std::lock_guard<std::mutex> lock(windows_mutex_);
       auto* state = GetWindow(window_id);
-      if (!state) return;
+      if (!state)
+        return;
       if (urlCopy.rfind("data:text/html,", 0) == 0) {
         NSString* html = [NSString stringWithUTF8String:urlCopy.c_str() + 15];
         html = [html stringByRemovingPercentEncoding];
@@ -307,7 +323,8 @@ void WKWebViewIOSBackend::ExecuteJs(uint32_t window_id,
       std::lock_guard<std::mutex> lock(windows_mutex_);
       auto* state = GetWindow(window_id);
       if (!state) {
-        if (callback) callback(nullptr, nullptr, callback_data);
+        if (callback)
+          callback(nullptr, nullptr, callback_data);
         return;
       }
       NSString* js = [NSString stringWithUTF8String:scriptCopy.c_str()];
@@ -337,7 +354,8 @@ void WKWebViewIOSBackend::EvalOnWindow(uint32_t window_id,
     @autoreleasepool {
       std::lock_guard<std::mutex> lock(windows_mutex_);
       auto* state = GetWindow(window_id);
-      if (!state) return;
+      if (!state)
+        return;
       NSString* js = [NSString stringWithUTF8String:scriptCopy.c_str()];
       [state->webview evaluateJavaScript:js completionHandler:nil];
     }


### PR DESCRIPTION
Adds a native iOS backend for laufey: the laufey C ABI on UIKit + WKWebView, so a laufey runtime (capi) can drive a native iOS app. Verified running on the iOS simulator.

### What
- **`webview/src/webview_ios.mm`** — `WKWebViewIOSBackend : LaufeyBackend`, the same backend seam `WKWebViewBackend` implements on macOS, ported to UIKit: a "window" is a `UIWindow` + root `UIViewController` hosting a `WKWebView`. The JS↔native bridge, value marshalling, and init script are shared with the desktop backends (`runtime_loader.cc` / `laufey_json.h` / `init_script.h`).
- **`webview/src/main_ios.mm`** — `UIApplicationMain` entry. iOS forbids loading arbitrary dylibs, so the runtime is **statically linked** and `laufey_runtime_init/start` are called directly via `RuntimeLoader::LoadStatic` (no dlopen). A `weak main` lets the same file serve a C-linked app or a Rust-linked one.
- **`runtime_loader.h`** — `LoadStatic()`: resolve the runtime entry points at link time instead of dlopen.
- **`examples/ios_hello`** — a laufey app (`Window` + `bind`) built as a static lib and linked in.
- **`ios/build.sh` + `Info.plist` + `README.md`** — compile the backend, link the runtime static lib, assemble `laufey.app`, install + launch on the booted simulator.

### Verified
On the iOS simulator: window opens, HTML renders, and the JS↔native bind round-trips (`Laufey.<method>()` → Rust handler → back).

### Not in this PR (follow-ups)
- Device builds: code signing, provisioning, `.ipa` packaging.
- Wiring the iOS backend into the CMake build (currently a standalone `clang++` script).
- Running the full Deno desktop runtime on iOS (separate WIP).

The iOS backend files are new and don't touch the existing desktop build, so this is additive.