### PR TITLE
fix(cef): native overlay scrollbars on Linux

### DIFF
--- a/cef/src/main_linux.cc
+++ b/cef/src/main_linux.cc
@@ -628,14 +628,14 @@ class LaufeyCombinedApp : public CefApp, public CefBrowserProcessHandler {
       }
     }
 
-    // Thin, auto-hiding "Fluent" overlay scrollbars so the webview matches the
+    // Thin, auto-hiding overlay scrollbars so the webview matches the
     // GNOME/Adwaita look instead of Chromium's chunky classic Linux scrollbars
-    // (issue #21). Only the browser process needs the switch; CEF propagates
-    // resolved features to its subprocesses. Skip if the embedder already set
-    // enable-features so we don't clobber their list.
+    // with stepper arrows (issue #21). Only the browser process needs the
+    // switch; CEF propagates resolved features to its subprocesses. Skip if the
+    // embedder already set enable-features so we don't clobber their list.
     if (process_type.empty() && !command_line->HasSwitch("enable-features")) {
-      command_line->AppendSwitchWithValue(
-          "enable-features", "FluentScrollbar,FluentOverlayScrollbar");
+      command_line->AppendSwitchWithValue("enable-features",
+                                          "OverlayScrollbar");
     }
   }
 

--- a/cef/src/main_linux.cc
+++ b/cef/src/main_linux.cc
@@ -627,6 +627,16 @@ class LaufeyCombinedApp : public CefApp, public CefBrowserProcessHandler {
         command_line->AppendSwitchWithValue("ozone-platform", "wayland");
       }
     }
+
+    // Thin, auto-hiding "Fluent" overlay scrollbars so the webview matches the
+    // GNOME/Adwaita look instead of Chromium's chunky classic Linux scrollbars
+    // (issue #21). Only the browser process needs the switch; CEF propagates
+    // resolved features to its subprocesses. Skip if the embedder already set
+    // enable-features so we don't clobber their list.
+    if (process_type.empty() && !command_line->HasSwitch("enable-features")) {
+      command_line->AppendSwitchWithValue(
+          "enable-features", "FluentScrollbar,FluentOverlayScrollbar");
+    }
   }
 
   void OnContextInitialized() override {


### PR DESCRIPTION
## Problem

Reported in #21: the CEF backend's scrollbars look ugly on GNOME — Chromium's chunky classic Linux scrollbar (solid track + stepper arrows) instead of the desktop's thin auto-hiding overlay.

## Fix

`cef/src/main_linux.cc` (`OnBeforeCommandLineProcessing`): enable `--enable-features=OverlayScrollbar` in the browser process → thin, auto-hiding overlay scrollbar that matches GNOME/Adwaita. CEF propagates the feature to subprocesses; skipped if the embedder already set `--enable-features`.

> Note: `FluentScrollbar`/`FluentOverlayScrollbar` (an earlier attempt) are **no longer recognized on Chromium 149** — verified the scrollbar stayed classic. `OverlayScrollbar` is the working feature.

## Before / after

Right-edge scrollbar, CEF 149 under mutter (4× crop):

| Before (classic track + stepper) | After (thin overlay thumb) |
|---|---|
| ![before](https://raw.githubusercontent.com/littledivy/laufey/assets/docs/issue-21/scrollbar-before-classic.png) | ![after](https://raw.githubusercontent.com/littledivy/laufey/assets/docs/issue-21/scrollbar-after-overlay.png) |

The overlay thumb is thin, rounded, track-less, and auto-hides at rest — the GNOME default.

## Note

Best stacked **on top of #24** (CEF 149 bump) — verified against a 149 build. Addresses the scrollbar half of #21 point 2.