### PR TITLE
fix(cef): native Wayland window decorations (bump CEF to 149)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,8 @@ else
   LIB_EXT := .a
 endif
 
-CEF_VERSION := 144.0.11
-CEF_FULL_VERSION := 144.0.11+ge135be2+chromium-144.0.7559.97
+CEF_VERSION := 149.0.5
+CEF_FULL_VERSION := 149.0.5+g6770623+chromium-149.0.7827.197
 CEF_URL_VERSION := $(subst +,%2B,$(CEF_FULL_VERSION))
 CEF_DOWNLOAD_URL := https://cef-builds.spotifycdn.com/cef_binary_$(CEF_URL_VERSION)_$(CEF_ARCH)_minimal.tar.bz2
 CEF_DIR := $(CURDIR)/vendor/cef

--- a/cef/flake.nix
+++ b/cef/flake.nix
@@ -13,8 +13,8 @@
 
         arch = if system == "aarch64-darwin" then "macosarm64" else "macosx64";
 
-        cefVersion = "144.0.11";
-        cefFullVersion = "144.0.11+ge135be2+chromium-144.0.7559.97";
+        cefVersion = "149.0.5";
+        cefFullVersion = "149.0.5+g6770623+chromium-149.0.7827.197";
 
         cefUrlVersion = builtins.replaceStrings ["+"] ["%2B"] cefFullVersion;
 
@@ -22,8 +22,8 @@
           url = "https://cef-builds.spotifycdn.com/cef_binary_${cefUrlVersion}_${arch}_minimal.tar.bz2";
           name = "cef-minimal.tar.bz2";
           hash = if system == "aarch64-darwin"
-            then "sha256-Q94fht0yAkwAIqv29I1ZkpaS7WiYvJIcHWFcmBSvqHw="
-            else "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+            then "sha256-hxGSmiBdNWSrmZPe/Fhr1R8jogqackmp3ohG14ZMxGM="
+            else "sha256-QMlnxsBsyyYI9hkaUsvH7pwg0P2Rpk8YkrVgALiWHlk=";
         };
 
         cef = pkgs.stdenv.mkDerivation {

--- a/examples/ddcore/index.html
+++ b/examples/ddcore/index.html
@@ -4,219 +4,219 @@
     <meta charset="UTF-8">
     <title>System Dashboard</title>
     <style>
-      ::-webkit-scrollbar {
-        display: none;
-      }
-      body {
-        font-family: system-ui, sans-serif;
-        background: #f5f5f7;
-        color: #444;
-        padding: 40px;
-        margin: 0;
-      }
-      h1 {
-        color: #1d1d1f;
-        font-size: 22px;
-        margin: 0 0 32px;
-        font-weight: 600;
-      }
-      h1 span {
-        color: #999;
-        font-weight: 400;
-      }
-      dl {
-        display: grid;
-        grid-template-columns: 120px 1fr;
-        gap: 8px 16px;
-        margin-bottom: 32px;
-      }
-      dt {
-        color: #888;
-        font-size: 13px;
-      }
-      dd {
-        color: #1d1d1f;
-        font-size: 13px;
-        margin: 0;
-      }
+    ::-webkit-scrollbar {
+      display: none;
+    }
+    body {
+      font-family: system-ui, sans-serif;
+      background: #f5f5f7;
+      color: #444;
+      padding: 40px;
+      margin: 0;
+    }
+    h1 {
+      color: #1d1d1f;
+      font-size: 22px;
+      margin: 0 0 32px;
+      font-weight: 600;
+    }
+    h1 span {
+      color: #999;
+      font-weight: 400;
+    }
+    dl {
+      display: grid;
+      grid-template-columns: 120px 1fr;
+      gap: 8px 16px;
+      margin-bottom: 32px;
+    }
+    dt {
+      color: #888;
+      font-size: 13px;
+    }
+    dd {
+      color: #1d1d1f;
+      font-size: 13px;
+      margin: 0;
+    }
 
-      .section-label {
-        font-size: 13px;
-        color: #888;
-        margin-bottom: 10px;
-      }
-      .cpu-grid {
-        display: grid;
-        grid-template-columns: repeat(4, 1fr);
-        gap: 8px;
-        margin-bottom: 24px;
-      }
-      .core {
-        background: #fff;
-        border-radius: 8px;
-        padding: 10px 12px;
-        position: relative;
-        overflow: hidden;
-      }
-      .core-bg {
-        position: absolute;
-        left: 0;
-        top: 0;
-        bottom: 0;
-        width: 0%;
-        background: linear-gradient(
-          90deg,
-          rgba(59, 130, 246, 0.18),
-          rgba(59, 130, 246, 0.35)
-        );
-        transition: width 0.8s cubic-bezier(0.4, 0, 0.2, 1), background 0.4s;
-      }
-      .core-bg.hot {
-        background: linear-gradient(
-          90deg,
-          rgba(239, 68, 68, 0.18),
-          rgba(239, 68, 68, 0.35)
-        );
-      }
-      .core-info {
-        position: relative;
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        font-size: 12px;
-      }
-      .core-label {
-        color: #999;
-        font-size: 11px;
-      }
-      .core-pct {
-        color: #1d1d1f;
-        font-weight: 600;
-        font-variant-numeric: tabular-nums;
-        transition: color 0.4s;
-      }
-      .core-pct.hot {
-        color: #ef4444;
-      }
+    .section-label {
+      font-size: 13px;
+      color: #888;
+      margin-bottom: 10px;
+    }
+    .cpu-grid {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 8px;
+      margin-bottom: 24px;
+    }
+    .core {
+      background: #fff;
+      border-radius: 8px;
+      padding: 10px 12px;
+      position: relative;
+      overflow: hidden;
+    }
+    .core-bg {
+      position: absolute;
+      left: 0;
+      top: 0;
+      bottom: 0;
+      width: 0%;
+      background: linear-gradient(
+        90deg,
+        rgba(59, 130, 246, 0.18),
+        rgba(59, 130, 246, 0.35)
+      );
+      transition: width 0.8s cubic-bezier(0.4, 0, 0.2, 1), background 0.4s;
+    }
+    .core-bg.hot {
+      background: linear-gradient(
+        90deg,
+        rgba(239, 68, 68, 0.18),
+        rgba(239, 68, 68, 0.35)
+      );
+    }
+    .core-info {
+      position: relative;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      font-size: 12px;
+    }
+    .core-label {
+      color: #999;
+      font-size: 11px;
+    }
+    .core-pct {
+      color: #1d1d1f;
+      font-weight: 600;
+      font-variant-numeric: tabular-nums;
+      transition: color 0.4s;
+    }
+    .core-pct.hot {
+      color: #ef4444;
+    }
 
-      .mem-card {
-        background: #fff;
-        border-radius: 8px;
-        padding: 10px 12px;
-        position: relative;
-        overflow: hidden;
-        margin-bottom: 24px;
-      }
-      .mem-bg {
-        position: absolute;
-        left: 0;
-        top: 0;
-        bottom: 0;
-        width: 0%;
-        background: linear-gradient(
-          90deg,
-          rgba(239, 68, 68, 0.18),
-          rgba(239, 68, 68, 0.35)
-        );
-        transition: width 0.8s cubic-bezier(0.4, 0, 0.2, 1);
-      }
-      .mem-info {
-        position: relative;
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        font-size: 12px;
-      }
-      .mem-label {
-        color: #999;
-        font-size: 11px;
-      }
-      .mem-pct {
-        color: #1d1d1f;
-        font-weight: 600;
-        font-variant-numeric: tabular-nums;
-      }
-      .mem-detail {
-        position: relative;
-        font-size: 11px;
-        color: #999;
-        margin-top: 2px;
-      }
-      .footer {
-        font-size: 11px;
-        color: #ccc;
-        margin-top: 40px;
-      }
-      #proc-search {
-        background: #fff;
-        border: 1px solid #ddd;
-        color: #333;
-        padding: 6px 10px;
-        font-size: 13px;
-        border-radius: 4px;
-        width: 240px;
-        margin-bottom: 12px;
-        outline: none;
-      }
-      #proc-search:focus {
-        border-color: #3b82f6;
-      }
-      #proc-table {
-        width: 100%;
-        border-collapse: collapse;
-        font-size: 12px;
-        font-variant-numeric: tabular-nums;
-        table-layout: fixed;
-      }
-      #proc-table th {
-        text-align: left;
-        color: #888;
-        font-weight: 500;
-        padding: 6px 8px;
-        border-bottom: 1px solid #ddd;
-        cursor: pointer;
-        user-select: none;
-        white-space: nowrap;
-      }
-      #proc-table th:hover {
-        color: #555;
-      }
-      #proc-table th .arrow {
-        font-size: 10px;
-        margin-left: 4px;
-      }
-      #proc-table td {
-        padding: 4px 8px;
-        border-bottom: 1px solid #eee;
-        color: #444;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-      }
-      #proc-table col.col-pid {
-        width: 70px;
-      }
-      #proc-table col.col-name {
-        width: auto;
-      }
-      #proc-table col.col-cpu {
-        width: 70px;
-      }
-      #proc-table col.col-mem {
-        width: 90px;
-      }
-      #proc-table tr:hover td {
-        background: #eef2ff;
-      }
-      .proc-section {
-        margin-top: 32px;
-      }
-      .proc-section h2 {
-        color: #1d1d1f;
-        font-size: 15px;
-        font-weight: 600;
-        margin: 0 0 12px;
-      }
+    .mem-card {
+      background: #fff;
+      border-radius: 8px;
+      padding: 10px 12px;
+      position: relative;
+      overflow: hidden;
+      margin-bottom: 24px;
+    }
+    .mem-bg {
+      position: absolute;
+      left: 0;
+      top: 0;
+      bottom: 0;
+      width: 0%;
+      background: linear-gradient(
+        90deg,
+        rgba(239, 68, 68, 0.18),
+        rgba(239, 68, 68, 0.35)
+      );
+      transition: width 0.8s cubic-bezier(0.4, 0, 0.2, 1);
+    }
+    .mem-info {
+      position: relative;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      font-size: 12px;
+    }
+    .mem-label {
+      color: #999;
+      font-size: 11px;
+    }
+    .mem-pct {
+      color: #1d1d1f;
+      font-weight: 600;
+      font-variant-numeric: tabular-nums;
+    }
+    .mem-detail {
+      position: relative;
+      font-size: 11px;
+      color: #999;
+      margin-top: 2px;
+    }
+    .footer {
+      font-size: 11px;
+      color: #ccc;
+      margin-top: 40px;
+    }
+    #proc-search {
+      background: #fff;
+      border: 1px solid #ddd;
+      color: #333;
+      padding: 6px 10px;
+      font-size: 13px;
+      border-radius: 4px;
+      width: 240px;
+      margin-bottom: 12px;
+      outline: none;
+    }
+    #proc-search:focus {
+      border-color: #3b82f6;
+    }
+    #proc-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 12px;
+      font-variant-numeric: tabular-nums;
+      table-layout: fixed;
+    }
+    #proc-table th {
+      text-align: left;
+      color: #888;
+      font-weight: 500;
+      padding: 6px 8px;
+      border-bottom: 1px solid #ddd;
+      cursor: pointer;
+      user-select: none;
+      white-space: nowrap;
+    }
+    #proc-table th:hover {
+      color: #555;
+    }
+    #proc-table th .arrow {
+      font-size: 10px;
+      margin-left: 4px;
+    }
+    #proc-table td {
+      padding: 4px 8px;
+      border-bottom: 1px solid #eee;
+      color: #444;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    #proc-table col.col-pid {
+      width: 70px;
+    }
+    #proc-table col.col-name {
+      width: auto;
+    }
+    #proc-table col.col-cpu {
+      width: 70px;
+    }
+    #proc-table col.col-mem {
+      width: 90px;
+    }
+    #proc-table tr:hover td {
+      background: #eef2ff;
+    }
+    .proc-section {
+      margin-top: 32px;
+    }
+    .proc-section h2 {
+      color: #1d1d1f;
+      font-size: 15px;
+      font-weight: 600;
+      margin: 0 0 12px;
+    }
     </style>
   </head>
   <body>
@@ -281,141 +281,138 @@
     <div class="footer">Powered by LAUFEY</div>
 
     <script>
-      function formatUptime(s) {
-        var d = Math.floor(s / 86400),
-          h = Math.floor((s % 86400) / 3600),
-          m = Math.floor((s % 3600) / 60);
-        if (d > 0) return d + "d " + h + "h " + m + "m";
-        if (h > 0) return h + "h " + m + "m";
-        return m + "m";
-      }
-      function updateSystemInfo(i) {
-        document.getElementById("hostname").textContent = i.hostname;
-        document.getElementById("os").textContent = i.os;
-        document.getElementById("arch").textContent = i.arch;
-        document.getElementById("cpu-model").textContent = i.cpuModel;
-        document.getElementById("cores").textContent = i.cores;
-        document.getElementById("total-mem").textContent =
-          Math.round(i.totalMemoryMb).toLocaleString() + " MB";
-      }
+    function formatUptime(s) {
+      var d = Math.floor(s / 86400),
+        h = Math.floor((s % 86400) / 3600),
+        m = Math.floor((s % 3600) / 60);
+      if (d > 0) return d + "d " + h + "h " + m + "m";
+      if (h > 0) return h + "h " + m + "m";
+      return m + "m";
+    }
+    function updateSystemInfo(i) {
+      document.getElementById("hostname").textContent = i.hostname;
+      document.getElementById("os").textContent = i.os;
+      document.getElementById("arch").textContent = i.arch;
+      document.getElementById("cpu-model").textContent = i.cpuModel;
+      document.getElementById("cores").textContent = i.cores;
+      document.getElementById("total-mem").textContent =
+        Math.round(i.totalMemoryMb).toLocaleString() + " MB";
+    }
 
-      var _coreEls = [];
-      function ensureCoreEls(n) {
-        if (_coreEls.length === n) return;
-        var grid = document.getElementById("cpu-grid");
-        grid.innerHTML = "";
-        _coreEls = [];
-        for (var i = 0; i < n; i++) {
-          var div = document.createElement("div");
-          div.className = "core";
-          div.innerHTML =
-            '<div class="core-bg"></div><div class="core-info"><span class="core-label">Core ' +
-            i + '</span><span class="core-pct">0%</span></div>';
-          grid.appendChild(div);
-          _coreEls.push({
-            bg: div.querySelector(".core-bg"),
-            pct: div.querySelector(".core-pct"),
-          });
-        }
-      }
-
-      function updateLiveStats(s) {
-        // Per-core CPU
-        if (s.perCore) {
-          ensureCoreEls(s.perCore.length);
-          for (var i = 0; i < s.perCore.length; i++) {
-            var v = Math.round(s.perCore[i]);
-            var el = _coreEls[i];
-            el.bg.style.width = v + "%";
-            el.pct.textContent = v + "%";
-            var hot = v > 80;
-            el.bg.className = "core-bg" + (hot ? " hot" : "");
-            el.pct.className = "core-pct" + (hot ? " hot" : "");
-          }
-        }
-        document.getElementById("cpu-avg").textContent =
-          Math.round(s.cpuUsage) + "%";
-
-        // Memory
-        var mem = Math.round((s.memUsedMb / s.memTotalMb) * 100);
-        document.getElementById("mem-bg").style.width = mem + "%";
-        document.getElementById("mem-pct").textContent = mem + "%";
-        document.getElementById("mem-detail").textContent =
-          Math.round(s.memUsedMb).toLocaleString() + " / " +
-          Math.round(s.memTotalMb).toLocaleString() + " MB";
-        document.getElementById("uptime").textContent = formatUptime(s.uptime);
-      }
-
-      var _procs = [], _sortCol = "cpuUsage", _sortAsc = false, _filter = "";
-
-      function renderProcs() {
-        var filtered = _procs.filter(function (p) {
-          return !_filter || p.name.toLowerCase().indexOf(_filter) !== -1;
+    var _coreEls = [];
+    function ensureCoreEls(n) {
+      if (_coreEls.length === n) return;
+      var grid = document.getElementById("cpu-grid");
+      grid.innerHTML = "";
+      _coreEls = [];
+      for (var i = 0; i < n; i++) {
+        var div = document.createElement("div");
+        div.className = "core";
+        div.innerHTML =
+          '<div class="core-bg"></div><div class="core-info"><span class="core-label">Core ' +
+          i + '</span><span class="core-pct">0%</span></div>';
+        grid.appendChild(div);
+        _coreEls.push({
+          bg: div.querySelector(".core-bg"),
+          pct: div.querySelector(".core-pct"),
         });
-        filtered.sort(function (a, b) {
-          var va = a[_sortCol], vb = b[_sortCol];
-          if (typeof va === "string") {
-            va = va.toLowerCase();
-            vb = vb.toLowerCase();
-          }
-          if (va < vb) return _sortAsc ? -1 : 1;
-          if (va > vb) return _sortAsc ? 1 : -1;
-          return 0;
-        });
-        var html = "";
-        for (var i = 0; i < filtered.length; i++) {
-          var p = filtered[i];
-          html += "<tr><td>" + p.pid + "</td><td>" + p.name + "</td><td>" +
-            p.cpuUsage.toFixed(1) + "</td><td>" + p.memoryMb.toFixed(1) +
-            "</td></tr>";
-        }
-        document.getElementById("proc-body").innerHTML = html;
-        var ths = document.querySelectorAll("#proc-table th");
-        for (var j = 0; j < ths.length; j++) {
-          var col = ths[j].getAttribute("data-col");
-          var arrow = col === _sortCol
-            ? (_sortAsc ? " \u25B2" : " \u25BC")
-            : "";
-          ths[j].innerHTML = ths[j].textContent.replace(/ [\u25B2\u25BC]/, "") +
-            "<span class='arrow'>" + arrow + "</span>";
+      }
+    }
+
+    function updateLiveStats(s) {
+      // Per-core CPU
+      if (s.perCore) {
+        ensureCoreEls(s.perCore.length);
+        for (var i = 0; i < s.perCore.length; i++) {
+          var v = Math.round(s.perCore[i]);
+          var el = _coreEls[i];
+          el.bg.style.width = v + "%";
+          el.pct.textContent = v + "%";
+          var hot = v > 80;
+          el.bg.className = "core-bg" + (hot ? " hot" : "");
+          el.pct.className = "core-pct" + (hot ? " hot" : "");
         }
       }
+      document.getElementById("cpu-avg").textContent = Math.round(s.cpuUsage) + "%";
 
-      function updateProcesses(procs) {
-        _procs = procs;
-        renderProcs();
-      }
+      // Memory
+      var mem = Math.round((s.memUsedMb / s.memTotalMb) * 100);
+      document.getElementById("mem-bg").style.width = mem + "%";
+      document.getElementById("mem-pct").textContent = mem + "%";
+      document.getElementById("mem-detail").textContent =
+        Math.round(s.memUsedMb).toLocaleString() + " / " +
+        Math.round(s.memTotalMb).toLocaleString() + " MB";
+      document.getElementById("uptime").textContent = formatUptime(s.uptime);
+    }
 
-      document.addEventListener("click", function (e) {
-        var th = e.target.closest("#proc-table th");
-        if (!th) return;
-        var col = th.getAttribute("data-col");
-        if (_sortCol === col) _sortAsc = !_sortAsc;
-        else {
-          _sortCol = col;
-          _sortAsc = col === "name";
+    var _procs = [], _sortCol = "cpuUsage", _sortAsc = false, _filter = "";
+
+    function renderProcs() {
+      var filtered = _procs.filter(function (p) {
+        return !_filter || p.name.toLowerCase().indexOf(_filter) !== -1;
+      });
+      filtered.sort(function (a, b) {
+        var va = a[_sortCol], vb = b[_sortCol];
+        if (typeof va === "string") {
+          va = va.toLowerCase();
+          vb = vb.toLowerCase();
         }
+        if (va < vb) return _sortAsc ? -1 : 1;
+        if (va > vb) return _sortAsc ? 1 : -1;
+        return 0;
+      });
+      var html = "";
+      for (var i = 0; i < filtered.length; i++) {
+        var p = filtered[i];
+        html += "<tr><td>" + p.pid + "</td><td>" + p.name + "</td><td>" +
+          p.cpuUsage.toFixed(1) + "</td><td>" + p.memoryMb.toFixed(1) +
+          "</td></tr>";
+      }
+      document.getElementById("proc-body").innerHTML = html;
+      var ths = document.querySelectorAll("#proc-table th");
+      for (var j = 0; j < ths.length; j++) {
+        var col = ths[j].getAttribute("data-col");
+        var arrow = col === _sortCol ? (_sortAsc ? " \u25B2" : " \u25BC") : "";
+        ths[j].innerHTML = ths[j].textContent.replace(/ [\u25B2\u25BC]/, "") +
+          "<span class='arrow'>" + arrow + "</span>";
+      }
+    }
+
+    function updateProcesses(procs) {
+      _procs = procs;
+      renderProcs();
+    }
+
+    document.addEventListener("click", function (e) {
+      var th = e.target.closest("#proc-table th");
+      if (!th) return;
+      var col = th.getAttribute("data-col");
+      if (_sortCol === col) _sortAsc = !_sortAsc;
+      else {
+        _sortCol = col;
+        _sortAsc = col === "name";
+      }
+      renderProcs();
+    });
+    document.getElementById("proc-search").addEventListener(
+      "input",
+      function (e) {
+        _filter = e.target.value.toLowerCase();
         renderProcs();
-      });
-      document.getElementById("proc-search").addEventListener(
-        "input",
-        function (e) {
-          _filter = e.target.value.toLowerCase();
-          renderProcs();
-        },
-      );
+      },
+    );
 
-      // Pull data from the runtime via bindings.
-      Laufey.getSystemInfo().then(function (r) {
-        updateSystemInfo(JSON.parse(r));
-      });
+    // Pull data from the runtime via bindings.
+    Laufey.getSystemInfo().then(function (r) {
+      updateSystemInfo(JSON.parse(r));
+    });
 
-      setInterval(async function () {
-        var stats = JSON.parse(await Laufey.getStats());
-        updateLiveStats(stats);
-        var procs = JSON.parse(await Laufey.getProcesses());
-        updateProcesses(procs);
-      }, 1000);
+    setInterval(async function () {
+      var stats = JSON.parse(await Laufey.getStats());
+      updateLiveStats(stats);
+      var procs = JSON.parse(await Laufey.getProcesses());
+      updateProcesses(procs);
+    }, 1000);
     </script>
   </body>
 </html>

--- a/examples/presentation/architecture.html
+++ b/examples/presentation/architecture.html
@@ -3,68 +3,68 @@
   <head>
     <meta charset="utf-8">
     <style>
-      body {
-        background: #fff;
-        color: #111;
-        font-family: system-ui, -apple-system, sans-serif;
-        padding: 48px;
-        max-width: 900px;
-        margin: 0 auto;
-      }
-      h1 {
-        font-size: 28px;
-        margin-bottom: 36px;
-        text-align: center;
-      }
-      .layer {
-        display: flex;
-        align-items: center;
-        gap: 24px;
-      }
-      .box {
-        border: 2px solid #111;
-        border-radius: 6px;
-        padding: 12px 20px;
-        text-align: center;
-        font-weight: 600;
-        font-size: 16px;
-        flex: 1;
-      }
-      .row {
-        display: flex;
-        gap: 12px;
-        flex: 1;
-      }
-      .row .box {
-        flex: 1;
-      }
-      .dashed {
-        border-style: dashed;
-      }
-      .gray {
-        border-color: #bbb;
-        color: #888;
-      }
-      .arrow {
-        text-align: center;
-        font-size: 18px;
-        color: #999;
-        margin: 6px 0;
-        padding-right: 180px;
-      }
-      .note {
-        width: 160px;
-        flex-shrink: 0;
-        text-align: left;
-        font-size: 13px;
-        color: #888;
-        font-style: italic;
-      }
-      .mono {
-        font-family: "SF Mono", monospace;
-        font-size: 12px;
-        font-style: normal;
-      }
+    body {
+      background: #fff;
+      color: #111;
+      font-family: system-ui, -apple-system, sans-serif;
+      padding: 48px;
+      max-width: 900px;
+      margin: 0 auto;
+    }
+    h1 {
+      font-size: 28px;
+      margin-bottom: 36px;
+      text-align: center;
+    }
+    .layer {
+      display: flex;
+      align-items: center;
+      gap: 24px;
+    }
+    .box {
+      border: 2px solid #111;
+      border-radius: 6px;
+      padding: 12px 20px;
+      text-align: center;
+      font-weight: 600;
+      font-size: 16px;
+      flex: 1;
+    }
+    .row {
+      display: flex;
+      gap: 12px;
+      flex: 1;
+    }
+    .row .box {
+      flex: 1;
+    }
+    .dashed {
+      border-style: dashed;
+    }
+    .gray {
+      border-color: #bbb;
+      color: #888;
+    }
+    .arrow {
+      text-align: center;
+      font-size: 18px;
+      color: #999;
+      margin: 6px 0;
+      padding-right: 180px;
+    }
+    .note {
+      width: 160px;
+      flex-shrink: 0;
+      text-align: left;
+      font-size: 13px;
+      color: #888;
+      font-style: italic;
+    }
+    .mono {
+      font-family: "SF Mono", monospace;
+      font-size: 12px;
+      font-style: normal;
+    }
     </style>
   </head>
   <body>


### PR DESCRIPTION
## Problem

Reported in #21: the CEF backend's window decorations look ugly on Fedora/GNOME Wayland — a dated, blue, old-Chrome title bar that doesn't match the desktop.

Native Wayland clients must draw their own client-side decorations (CSD), and CEF < 149 drew an ancient Chrome frame — tracked upstream in [chromiumembedded/cef#4061](https://github.com/chromiumembedded/cef/issues/4061). (Same root cause as Spotify's [flathub#317](https://github.com/flathub/com.spotify.Client/issues/317), which is also CEF.)

## Fix

Chromium **M149** fixes it ([CL 7709824](https://chromium-review.googlesource.com/c/chromium/src/+/7709824) + [CL 7615475](https://chromium-review.googlesource.com/c/chromium/src/+/7615475)) — native Wayland windows now get **GTK-themed CSD that matches the system**. Maintainer confirmed on cef#4061: *"With the update to M149, this is now fixed."*

So bump CEF **144.0.11 → 149.0.5**. laufey's CEF backend compiles unchanged against 149.

- `Makefile`: `CEF_VERSION` / `CEF_FULL_VERSION`
- `cef/flake.nix`: `cefVersion` / `cefFullVersion` + refreshed darwin hashes (also fills the previously-placeholder x86_64-darwin hash)

## Before / after (native Wayland)

Verified under nested **mutter** (GNOME's compositor) on the test VM, native-Wayland build.

**Before — CEF 144, native Wayland (dated blue CSD):**

![before](https://raw.githubusercontent.com/littledivy/laufey/assets/docs/issue-21/cef-frame-before-wayland.png)

**After — CEF 149, native Wayland (native Adwaita CSD):**

![after frame](https://raw.githubusercontent.com/littledivy/laufey/assets/docs/issue-21/cef-frame-after-149-wayland.png)

![after window](https://raw.githubusercontent.com/littledivy/laufey/assets/docs/issue-21/cef-window-after-149-wayland.png)

Native Adwaita header bar, centered title, native window controls — on **native Wayland** (no XWayland), so fractional scaling is preserved too.

## Notes

- This supersedes the X11/XWayland workaround approach (forcing `--ozone-platform=x11`, as Spotish/Spotify users do manually) — the bump fixes native Wayland directly, keeping crisp fractional scaling.
- Needs a normal CEF-bump validation pass in CI (all CEF targets build + e2e). Compiles clean locally on Linux against 149.

Closes the decoration half of #21.