### PR TITLE
fix(cef): disable background networking to silence GCM errors

### DIFF
--- a/cef/src/app.h
+++ b/cef/src/app.h
@@ -128,6 +128,18 @@ class LaufeyApp : public CefApp, public CefBrowserProcessHandler {
       const CefString& process_type,
       CefRefPtr<CefCommandLine> command_line) override {
     command_line->AppendSwitch("use-mock-keychain");
+
+    // Silence Chromium's background networking. The GCM (Google Cloud
+    // Messaging) client tries to register on startup and logs noisy
+    // `registration_request.cc ... PHONE_REGISTRATION_ERROR` /
+    // `DEPRECATED_ENDPOINT` errors that have nothing to do with the app. A
+    // webview-embedding desktop app doesn't use GCM, the component updater,
+    // safebrowsing auto-update, etc., so disable the lot (matches what
+    // Electron/Puppeteer do). Only the browser process needs the switch; CEF
+    // propagates it to subprocesses.
+    if (process_type.empty()) {
+      command_line->AppendSwitch("disable-background-networking");
+    }
   }
 
   void OnContextInitialized() override;

--- a/cef/src/main_linux.cc
+++ b/cef/src/main_linux.cc
@@ -637,6 +637,18 @@ class LaufeyCombinedApp : public CefApp, public CefBrowserProcessHandler {
       command_line->AppendSwitchWithValue("enable-features",
                                           "OverlayScrollbar");
     }
+
+    // Silence Chromium's background networking. The GCM (Google Cloud
+    // Messaging) client tries to register on startup and logs noisy
+    // `registration_request.cc ... PHONE_REGISTRATION_ERROR` /
+    // `DEPRECATED_ENDPOINT` errors that have nothing to do with the app. A
+    // webview-embedding desktop app doesn't use GCM, the component updater,
+    // safebrowsing auto-update, etc., so disable the lot (matches what
+    // Electron/Puppeteer do). Only the browser process needs the switch; CEF
+    // propagates it to subprocesses.
+    if (process_type.empty()) {
+      command_line->AppendSwitch("disable-background-networking");
+    }
   }
 
   void OnContextInitialized() override {

--- a/cef/src/main_windows.cc
+++ b/cef/src/main_windows.cc
@@ -175,7 +175,17 @@ class LaufeyCombinedApp : public CefApp, public CefBrowserProcessHandler {
   void OnBeforeCommandLineProcessing(
       const CefString& process_type,
       CefRefPtr<CefCommandLine> command_line) override {
-    // No macOS-specific flags needed on Windows
+    // Silence Chromium's background networking. The GCM (Google Cloud
+    // Messaging) client tries to register on startup and logs noisy
+    // `registration_request.cc ... PHONE_REGISTRATION_ERROR` /
+    // `DEPRECATED_ENDPOINT` errors that have nothing to do with the app. A
+    // webview-embedding desktop app doesn't use GCM, the component updater,
+    // safebrowsing auto-update, etc., so disable the lot (matches what
+    // Electron/Puppeteer do). Only the browser process needs the switch; CEF
+    // propagates it to subprocesses.
+    if (process_type.empty()) {
+      command_line->AppendSwitch("disable-background-networking");
+    }
   }
 
   void OnContextInitialized() override {


### PR DESCRIPTION
When running a desktop app with the CEF backend, the terminal fills up
with Chromium error logs that have nothing to do with the app:

```
[ERROR:google_apis/gcm/engine/registration_request.cc:291] Registration
response error message: DEPRECATED_ENDPOINT
```

(plus repeated `PHONE_REGISTRATION_ERROR` variants). These come from
Chromium's GCM (Google Cloud Messaging) client, which registers with
Google's push endpoint on startup, fails, and logs at `LOG(ERROR)`. An
embedded webview app has no use for GCM.

This appends the standard `--disable-background-networking` switch in the
browser process for all three platform command-line hooks
(`LaufeyApp` on macOS, `LaufeyCombinedApp` on Linux/Windows). It's a
root-cause fix: GCM never registers, so the errors are never generated,
rather than just hiding log lines. It also disables the component
updater, Safe Browsing auto-update, captive-portal detection, etc. —
none of which an embedded webview needs. This mirrors what Electron and
Puppeteer enable by default.

Reported in denoland/deno#35498.