### PR TITLE
fix(webview): avoid macOS window visibility deadlock

### DIFF
--- a/webview/src/webview_macos.mm
+++ b/webview/src/webview_macos.mm
@@ -523,6 +523,8 @@ void WKWebViewBackend::RemoveWindowState(uint32_t window_id) {
     if (state.webview)
       [state.webview.configuration.userContentController
           removeScriptMessageHandlerForName:@"laufey"];
+    if (state.window)
+      [state.window setDelegate:nil];
     UnregisterNSWindow(state.window);
   }
   windows_.erase(it);
@@ -876,13 +878,18 @@ void WKWebViewBackend::CreateWindowEx(uint32_t window_id, int width, int height,
 void WKWebViewBackend::CloseWindow(uint32_t window_id) {
   dispatch_async(dispatch_get_main_queue(), ^{
     @autoreleasepool {
-      std::lock_guard<std::mutex> lock(windows_mutex_);
-      auto it = windows_.find(window_id);
-      if (it != windows_.end()) {
-        NSWindow* win = it->second.window;
+      NSWindow* win = nil;
+      {
+        std::lock_guard<std::mutex> lock(windows_mutex_);
+        auto it = windows_.find(window_id);
+        if (it == windows_.end())
+          return;
+        win = it->second.window;
         RemoveWindowState(window_id);
-        [win close];
       }
+      if (!win)
+        return;
+      [win close];
     }
   });
 }
@@ -1174,11 +1181,17 @@ bool WKWebViewBackend::IsVisible(uint32_t window_id) {
 void WKWebViewBackend::Show(uint32_t window_id) {
   dispatch_async(dispatch_get_main_queue(), ^{
     @autoreleasepool {
-      std::lock_guard<std::mutex> lock(windows_mutex_);
-      auto* state = GetWindow(window_id);
-      if (state) {
-        [state->window makeKeyAndOrderFront:nil];
+      NSWindow* win = nil;
+      {
+        std::lock_guard<std::mutex> lock(windows_mutex_);
+        auto* state = GetWindow(window_id);
+        if (state) {
+          win = state->window;
+        }
       }
+      if (!win)
+        return;
+      [win makeKeyAndOrderFront:nil];
     }
   });
 }
@@ -1186,11 +1199,17 @@ void WKWebViewBackend::Show(uint32_t window_id) {
 void WKWebViewBackend::Hide(uint32_t window_id) {
   dispatch_async(dispatch_get_main_queue(), ^{
     @autoreleasepool {
-      std::lock_guard<std::mutex> lock(windows_mutex_);
-      auto* state = GetWindow(window_id);
-      if (state) {
-        [state->window orderOut:nil];
+      NSWindow* win = nil;
+      {
+        std::lock_guard<std::mutex> lock(windows_mutex_);
+        auto* state = GetWindow(window_id);
+        if (state) {
+          win = state->window;
+        }
       }
+      if (!win)
+        return;
+      [win orderOut:nil];
     }
   });
 }
@@ -1198,11 +1217,17 @@ void WKWebViewBackend::Hide(uint32_t window_id) {
 void WKWebViewBackend::Focus(uint32_t window_id) {
   dispatch_async(dispatch_get_main_queue(), ^{
     @autoreleasepool {
-      std::lock_guard<std::mutex> lock(windows_mutex_);
-      auto* state = GetWindow(window_id);
-      if (state) {
+      NSWindow* win = nil;
+      {
+        std::lock_guard<std::mutex> lock(windows_mutex_);
+        auto* state = GetWindow(window_id);
+        if (state) {
+          win = state->window;
+        }
+      }
+      if (win) {
         [NSApp activateIgnoringOtherApps:YES];
-        [state->window makeKeyAndOrderFront:nil];
+        [win makeKeyAndOrderFront:nil];
       }
     }
   });


### PR DESCRIPTION
Fixes a macOS deadlock when programmatically closing, hiding, showing, or focusing a secondary WKWebView window.

Deno issue context: denoland/deno#35568 reports `Deno.BrowserWindow.close()` / `hide()` hanging the UI for secondary windows on macOS.

The backend currently holds `windows_mutex_` while calling AppKit window APIs such as `-[NSWindow orderOut:]`, `-[NSWindow makeKeyAndOrderFront:]`, and `-[NSWindow close]`. Those calls can synchronously fire focus/blur/window notifications, and the installed observers re-enter `windows_mutex_`, deadlocking the main thread.

This patch copies the `NSWindow*` while holding the mutex, releases the mutex, and only then invokes AppKit. For programmatic close, it also clears the window delegate during state removal so `-[NSWindow close]` is not intercepted by `windowShouldClose:` and converted back into a close-request event.

Validation run locally on macOS:

- `make check-deps`
- `make webview`
- `make fmt-check`
- `cargo test -p laufey --lib`
- `make lint`
- `clang++ -fsyntax-only -x objective-c++ -std=c++17 -fobjc-arc -Iwebview/src -Ibackend-common/include -Icapi/include webview/src/webview_macos.mm -framework Cocoa -framework WebKit -framework UserNotifications`