### PR TITLE
feat: open external links in the OS browser

### DIFF
--- a/capi/include/laufey_external_links.h
+++ b/capi/include/laufey_external_links.h
@@ -1,0 +1,122 @@
+// Copyright 2025 Divy Srivastava. All rights reserved. MIT license.
+// Shared policy for redirecting external link navigations to the OS browser.
+//
+// Clicking an `<a href="https://…">` inside a webview would otherwise replace
+// the app's view with the remote page. To match the behavior apps expect
+// (external links open in the user's browser, the app keeps running), every
+// page is injected with a standards-based Navigation API listener that cancels
+// such navigations and hands the URL to the native side via a reserved bridge
+// call.
+//
+// This header is the single source of truth shared by every backend: the
+// system WebView backends (webview/src/init_script.h) and the CEF renderer
+// (cef/src/render_process_handler.cc). The reserved method name is also matched
+// natively by each backend's call dispatcher, which routes it to the
+// platform's open-in-browser primitive instead of the runtime.
+
+#ifndef LAUFEY_EXTERNAL_LINKS_H_
+#define LAUFEY_EXTERNAL_LINKS_H_
+
+#include <string>
+
+// Reserved bridge method. The injected listener calls
+// `window[ns].__laufeyOpenExternal(url)`; each backend intercepts a call with
+// this path before it reaches the runtime and opens `url` in the OS browser.
+#define LAUFEY_OPEN_EXTERNAL_METHOD "__laufeyOpenExternal"
+
+// Builds the page-side interceptor for the namespace `ns` (the global the
+// laufey bridge proxy is installed under, e.g. "laufey").
+//
+// Policy (hardcoded by design — see the conversation around this feature):
+// only user-initiated, cancelable, cross-origin http(s) navigations are
+// redirected. Same-origin navigations (SPA routing, multi-page apps) and the
+// app's own `laufey://` scheme stay in the view. Downloads, reloads, history
+// traversals and fragment changes are left alone.
+//
+// Two mechanisms, picked at runtime by capability:
+//   * Navigation API (`window.navigation`): the modern, comprehensive path —
+//     also catches `location.href = …`, form submits, etc. Used on Chromium
+//     (CEF) and WebView2.
+//   * Click-capture fallback: used when the Navigation API is absent (notably
+//     WKWebView on macOS/iOS, which does not expose it). Intercepts plain left
+//     clicks on `<a>` elements. Narrower than the Navigation API but covers the
+//     "clicked a link" case across every engine.
+// Exactly one runs, so a link is never handled twice.
+//
+// Both only cover same-window navigations — `target="_blank"` and
+// `window.open()` never reach either and are handled by each backend's
+// new-window hook instead.
+inline std::string BuildExternalLinkInterceptScript(const std::string& ns) {
+  return R"JS(
+(function() {
+  var ns = ")JS" +
+         ns + R"JS(";
+
+  // True for http(s) destinations whose origin differs from the document's.
+  // location.origin is "null" for opaque-origin documents (e.g. data: URLs),
+  // so any real http(s) link counts as external there.
+  function isExternal(href) {
+    var dest;
+    try { dest = new URL(href, location.href); } catch (e) { return null; }
+    if (dest.protocol !== 'http:' && dest.protocol !== 'https:') return null;
+    if (dest.origin === location.origin) return null;
+    return dest.href;
+  }
+
+  function openExternal(href) {
+    var bridge = window[ns];
+    if (bridge) {
+      bridge.__laufeyOpenExternal(href);
+    }
+  }
+
+  if (window.navigation &&
+      typeof window.navigation.addEventListener === 'function') {
+    window.navigation.addEventListener('navigate', function(e) {
+      try {
+        if (!e.userInitiated || !e.cancelable || e.downloadRequest ||
+            e.hashChange || e.navigationType === 'reload' ||
+            e.navigationType === 'traverse') {
+          return;
+        }
+        var href = isExternal(e.destination.url);
+        if (href) {
+          e.preventDefault();
+          openExternal(href);
+        }
+      } catch (err) {
+        // Never let the policy break in-page navigation.
+      }
+    });
+    return;
+  }
+
+  // Fallback: no Navigation API. Intercept plain left clicks on anchors.
+  document.addEventListener('click', function(e) {
+    try {
+      if (e.defaultPrevented || e.button !== 0) return;
+      var el = e.target;
+      while (el && el.nodeType === 1 &&
+             (el.tagName === undefined || el.tagName.toUpperCase() !== 'A')) {
+        el = el.parentNode;
+      }
+      if (!el || !el.tagName || el.tagName.toUpperCase() !== 'A') return;
+      // `target="_blank"` is handled by the backend's new-window hook.
+      var target = el.getAttribute('target');
+      if (target && target !== '_self') return;
+      var href = el.href;
+      if (!href) return;
+      var external = isExternal(href);
+      if (external) {
+        e.preventDefault();
+        openExternal(external);
+      }
+    } catch (err) {
+      // Never let the policy break in-page navigation.
+    }
+  }, true);
+})();
+)JS";
+}
+
+#endif  // LAUFEY_EXTERNAL_LINKS_H_

--- a/cef/CMakeLists.txt
+++ b/cef/CMakeLists.txt
@@ -11,6 +11,14 @@ endif()
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# CEF 149's headers (e.g. base/cef_scoped_refptr.h) use C++20 concepts such as
+# std::same_as. The C++ sources pick this up from libcef_dll_wrapper's
+# cxx_std_20 INTERFACE compile feature, but that feature only applies to the
+# CXX language — Objective-C++ (.mm) sources fall back to the project default
+# and fail to compile. Set the ObjC++ standard to C++20 to match.
+set(CMAKE_OBJCXX_STANDARD 20)
+set(CMAKE_OBJCXX_STANDARD_REQUIRED ON)
+
 set(LAUFEY_RENDERER_SRCS
   src/render_process_handler.cc
   src/render_process_handler.h

--- a/cef/src/app.cc
+++ b/cef/src/app.cc
@@ -3,6 +3,7 @@
 #include "app.h"
 #include "runtime_loader.h"
 #include "laufey_backend_common.h"
+#include "laufey_external_links.h"
 #include "scheme_handler.h"
 
 #include <iostream>
@@ -133,6 +134,24 @@ void LaufeyHandler::OnAfterCreated(CefRefPtr<CefBrowser> browser) {
     g_pending_laufey_ids.pop();
     loader->RegisterBrowser(laufey_id, browser);
   }
+}
+
+bool LaufeyHandler::OnBeforePopup(
+    CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, int popup_id,
+    const CefString& target_url, const CefString& target_frame_name,
+    WindowOpenDisposition target_disposition, bool user_gesture,
+    const CefPopupFeatures& popupFeatures, CefWindowInfo& windowInfo,
+    CefRefPtr<CefClient>& client, CefBrowserSettings& settings,
+    CefRefPtr<CefDictionaryValue>& extra_info, bool* no_javascript_access) {
+  CEF_REQUIRE_UI_THREAD();
+  // `target="_blank"` / `window.open()` aren't seen by the page's Navigation
+  // API listener. Cancel the popup and route http(s) destinations to the OS
+  // browser; return true to prevent the new browser from being created.
+  std::string url = target_url.ToString();
+  if (url.rfind("http://", 0) == 0 || url.rfind("https://", 0) == 0) {
+    LaufeyOpenExternalURL(url);
+  }
+  return true;
 }
 
 bool LaufeyHandler::DoClose(CefRefPtr<CefBrowser> browser) {
@@ -358,6 +377,27 @@ bool LaufeyHandler::OnProcessMessageReceived(
     uint64_t call_id = static_cast<uint64_t>(args->GetDouble(0));
     std::string method_path = args->GetString(1).ToString();
     CefRefPtr<CefListValue> callArgs = args->GetList(2);
+
+    // Reserved bridge call from the injected external-link interceptor
+    // (laufey_external_links.h): open the URL in the OS browser instead of
+    // forwarding to the runtime, then resolve the page-side promise.
+    if (method_path == LAUFEY_OPEN_EXTERNAL_METHOD) {
+      if (callArgs && callArgs->GetSize() > 0 &&
+          callArgs->GetType(0) == VTYPE_STRING) {
+        std::string url = callArgs->GetString(0).ToString();
+        if (!url.empty()) {
+          LaufeyOpenExternalURL(url);
+        }
+      }
+      CefRefPtr<CefProcessMessage> reply =
+          CefProcessMessage::Create("laufey_response");
+      CefRefPtr<CefListValue> replyArgs = reply->GetArgumentList();
+      replyArgs->SetDouble(0, static_cast<double>(call_id));
+      replyArgs->SetNull(1);
+      replyArgs->SetString(2, "");
+      frame->SendProcessMessage(PID_RENDERER, reply);
+      return true;
+    }
 
     uint32_t wid = RuntimeLoader::GetInstance()->GetLaufeyIdForBrowser(browser);
     RuntimeLoader::GetInstance()->OnJsCall(wid, call_id, method_path, callArgs);

--- a/cef/src/app.h
+++ b/cef/src/app.h
@@ -16,6 +16,11 @@
 
 extern std::string g_runtime_path;
 
+// Open `url` in the user's default OS browser. Implemented per platform in
+// main_mac.mm / main_windows.cc / main_linux.cc. Used to honor the external
+// link redirect policy (laufey_external_links.h).
+void LaufeyOpenExternalURL(const std::string& url);
+
 // Queue of laufey window IDs waiting for OnAfterCreated to fire.
 // Push before CreateBrowserView, pop in OnAfterCreated.
 // Both happen on the UI thread so no synchronization needed.
@@ -82,6 +87,18 @@ class LaufeyHandler : public CefClient,
       const std::vector<CefDraggableRegion>& regions) override;
 
   void OnAfterCreated(CefRefPtr<CefBrowser> browser) override;
+  // `target="_blank"` / `window.open()` requests aren't seen by the page's
+  // Navigation API listener; cancel the popup and open http(s) destinations in
+  // the OS browser instead.
+  bool OnBeforePopup(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame,
+                     int popup_id, const CefString& target_url,
+                     const CefString& target_frame_name,
+                     WindowOpenDisposition target_disposition,
+                     bool user_gesture, const CefPopupFeatures& popupFeatures,
+                     CefWindowInfo& windowInfo, CefRefPtr<CefClient>& client,
+                     CefBrowserSettings& settings,
+                     CefRefPtr<CefDictionaryValue>& extra_info,
+                     bool* no_javascript_access) override;
   bool DoClose(CefRefPtr<CefBrowser> browser) override;
   void OnBeforeClose(CefRefPtr<CefBrowser> browser) override;
 

--- a/cef/src/main_linux.cc
+++ b/cef/src/main_linux.cc
@@ -19,6 +19,12 @@
 #include "renderer_app.h"
 #include "runtime_loader.h"
 
+#include <gio/gio.h>
+
+void LaufeyOpenExternalURL(const std::string& url) {
+  g_app_info_launch_default_for_uri(url.c_str(), nullptr, nullptr);
+}
+
 // --- Native event monitors (Linux / X11) ---
 // Uses XI2 (X Input Extension 2) on a dedicated X11 connection to monitor
 // mouse, scroll, cursor enter/leave, and focus events for CEF Views windows.

--- a/cef/src/main_mac.mm
+++ b/cef/src/main_mac.mm
@@ -14,6 +14,16 @@
 #include "runtime_loader.h"
 #include "laufey_backend_common.h"
 
+void LaufeyOpenExternalURL(const std::string& url) {
+  @autoreleasepool {
+    NSURL* nsurl =
+        [NSURL URLWithString:[NSString stringWithUTF8String:url.c_str()]];
+    if (nsurl) {
+      [[NSWorkspace sharedWorkspace] openURL:nsurl];
+    }
+  }
+}
+
 @interface LaufeyApplication : NSApplication <CefAppProtocol> {
  @private
   BOOL handlingSendEvent_;

--- a/cef/src/main_windows.cc
+++ b/cef/src/main_windows.cc
@@ -20,6 +20,16 @@
 #include "renderer_app.h"
 #include "runtime_loader.h"
 
+void LaufeyOpenExternalURL(const std::string& url) {
+  int wlen = MultiByteToWideChar(CP_UTF8, 0, url.c_str(), -1, nullptr, 0);
+  if (wlen <= 0)
+    return;
+  std::wstring wurl(static_cast<size_t>(wlen - 1), L'\0');
+  MultiByteToWideChar(CP_UTF8, 0, url.c_str(), -1, &wurl[0], wlen);
+  ShellExecuteW(nullptr, L"open", wurl.c_str(), nullptr, nullptr,
+                SW_SHOWNORMAL);
+}
+
 // Windows mouse/input monitor for CEF Views windows.
 // CEF Views creates its own HWND; we hook into it after window creation.
 

--- a/cef/src/render_process_handler.cc
+++ b/cef/src/render_process_handler.cc
@@ -2,6 +2,8 @@
 
 #include "render_process_handler.h"
 
+#include "laufey_external_links.h"
+
 CefRefPtr<LaufeyRenderProcessHandler> g_render_handler;
 
 LaufeyPathObject::LaufeyPathObject(std::vector<std::string> path,
@@ -167,6 +169,13 @@ void LaufeyRenderProcessHandler::OnContextCreated(
   CefRefPtr<CefV8Value> laufey = CefV8Value::CreateObject(nullptr, handler);
 
   global->SetValue(ns, laufey, V8_PROPERTY_ATTRIBUTE_READONLY);
+
+  // Redirect external link navigations to the OS browser via the standards
+  // based Navigation API (laufey_external_links.h). The injected listener calls
+  // `window[ns].__laufeyOpenExternal(url)`, which the browser process
+  // intercepts before dispatching to the runtime.
+  frame->ExecuteJavaScript(BuildExternalLinkInterceptScript(ns),
+                           frame->GetURL(), 0);
 }
 
 void LaufeyRenderProcessHandler::OnContextReleased(

--- a/examples/hello/src/lib.rs
+++ b/examples/hello/src/lib.rs
@@ -134,6 +134,16 @@ fn hello_main() {
         <button onclick="testInfo()">Laufey.getInfo()</button>
         <button onclick="testUnknown()">Laufey.unknown()</button>
     </div>
+    <h2>External Links</h2>
+    <p>These should open in your default browser, not navigate this window:</p>
+    <div style="line-height: 2;">
+        <a href="https://example.com" style="color: %2300d4ff;">In-place link to example.com</a><br>
+        <a href="https://deno.com" target="_blank" style="color: %2300d4ff;">target=_blank link to deno.com</a>
+    </div>
+    <p>This one stays in the app (same-document fragment link, not intercepted):</p>
+    <div style="line-height: 2;">
+        <a href="%23more-info" style="color: %2300ff88;">In-page anchor &#8594; jump to section below</a>
+    </div>
     <h2>Dock / Taskbar</h2>
     <div>
         <button onclick="Laufey.setDockBadge('3')">Badge "3"</button>
@@ -145,6 +155,10 @@ fn hello_main() {
         <button onclick="Laufey.setDockVisible(true)">Show in Dock</button>
     </div>
     <pre id="output">Click a button to test...</pre>
+    <div style="height: 400px;"></div>
+    <h2 id="more-info">More info</h2>
+    <p>You jumped here from the in-page anchor without leaving the app &#8212;
+    the external-link policy only redirects cross-origin http(s) navigations.</p>
     <script>
         const out = document.getElementById('output');
         function log(msg, isError) {

--- a/webview/src/init_script.h
+++ b/webview/src/init_script.h
@@ -11,6 +11,8 @@
 #include <cstdint>
 #include <string>
 
+#include "laufey_external_links.h"
+
 // The host->page side of the bridge protocol. These build the JS statements
 // that call the functions defined by BuildInitScript() below, so the function
 // names live in exactly one place. Each platform backend builds the statement
@@ -143,7 +145,7 @@ inline std::string BuildInitScript(const std::string& ns,
   };
 
 })();
-)JS";
+)JS" + BuildExternalLinkInterceptScript(ns);
 }
 
 #endif  // LAUFEY_WEBVIEW_INIT_SCRIPT_H_

--- a/webview/src/runtime_loader.cc
+++ b/webview/src/runtime_loader.cc
@@ -2,6 +2,8 @@
 
 #include "runtime_loader.h"
 
+#include "laufey_external_links.h"
+
 #ifndef _WIN32
 #include <dlfcn.h>
 #else
@@ -865,6 +867,27 @@ void RuntimeLoader::PollPendingJsCalls() {
   }
 
   for (auto& call : calls) {
+    // Reserved bridge call from the injected external-link interceptor
+    // (laufey_external_links.h): open the URL in the OS browser instead of
+    // forwarding to the runtime, then resolve the page-side promise.
+    if (call.method_path == LAUFEY_OPEN_EXTERNAL_METHOD) {
+      std::string url;
+      if (call.args && call.args->IsList()) {
+        const laufey::ValueList& list = call.args->GetList();
+        if (!list.empty() && list[0] && list[0]->IsString()) {
+          url = list[0]->GetString();
+        }
+      }
+      if (!url.empty()) {
+        if (LaufeyBackend* backend = GetBackend()) {
+          backend->OpenExternalURL(url);
+        }
+      }
+      JsCallRespond(call.window_id, call.call_id, laufey::Value::Null(),
+                    nullptr);
+      continue;
+    }
+
     if (handler) {
       laufey_value_t* argsWrapper = new laufey_value(call.args);
       handler(user_data, call.window_id, call.call_id, call.method_path.c_str(),

--- a/webview/src/runtime_loader.h
+++ b/webview/src/runtime_loader.h
@@ -411,6 +411,12 @@ class LaufeyBackend {
 
   virtual void OpenDevTools(uint32_t window_id) = 0;
 
+  // Open `url` in the user's default OS browser. Used to honor the
+  // external-link redirect policy (see laufey_external_links.h) so clicked
+  // links and `target="_blank"` popups leave the app's webview. Default no-op;
+  // platform backends override with the native open-in-browser call.
+  virtual void OpenExternalURL(const std::string& /*url*/) {}
+
   // --- Custom URL scheme handler (API >= 26) ---
   // Install a native handler for `scheme` so requests to <scheme>://… are
   // delivered to RuntimeLoader::DispatchSchemeRequest. Default no-op: backends

--- a/webview/src/webview_ios.mm
+++ b/webview/src/webview_ios.mm
@@ -46,6 +46,7 @@ class WKWebViewIOSBackend : public LaufeyBackend {
   void CloseWindow(uint32_t window_id) override;
 
   void Navigate(uint32_t window_id, const std::string& url) override;
+  void OpenExternalURL(const std::string& url) override;
   void SetTitle(uint32_t /*window_id*/, const std::string& /*title*/) override {
   }
   void ExecuteJs(uint32_t window_id, const std::string& script,
@@ -286,6 +287,21 @@ void WKWebViewIOSBackend::CloseWindow(uint32_t window_id) {
         return;
       it->second.window.hidden = YES;
       windows_.erase(it);
+    }
+  });
+}
+
+void WKWebViewIOSBackend::OpenExternalURL(const std::string& url) {
+  std::string urlCopy = url;
+  dispatch_async(dispatch_get_main_queue(), ^{
+    @autoreleasepool {
+      NSURL* nsurl =
+          [NSURL URLWithString:[NSString stringWithUTF8String:urlCopy.c_str()]];
+      if (nsurl) {
+        [[UIApplication sharedApplication] openURL:nsurl
+                                           options:@{}
+                                 completionHandler:nil];
+      }
     }
   });
 }

--- a/webview/src/webview_linux.cc
+++ b/webview/src/webview_linux.cc
@@ -296,6 +296,22 @@ static void on_load_changed(WebKitWebView* /*webview*/,
   RuntimeLoader::GetInstance()->DispatchPageLoadEvent(wid);
 }
 
+// Fired when the page requests a new webview (`target="_blank"` or
+// `window.open()`). These never reach the Navigation API interceptor, so route
+// http(s) destinations to the OS browser and create no new webview.
+static WebKitWebView* on_create(WebKitWebView* /*webview*/,
+                                WebKitNavigationAction* navigation_action,
+                                gpointer /*user_data*/) {
+  WebKitURIRequest* req =
+      webkit_navigation_action_get_request(navigation_action);
+  const char* uri = req ? webkit_uri_request_get_uri(req) : nullptr;
+  if (uri &&
+      (g_str_has_prefix(uri, "http://") || g_str_has_prefix(uri, "https://"))) {
+    g_app_info_launch_default_for_uri(uri, nullptr, nullptr);
+  }
+  return nullptr;
+}
+
 static gboolean on_key_event(GtkWidget* widget, GdkEventKey* event,
                              gpointer user_data) {
   uint32_t wid = LaufeyIdForWidget(widget);
@@ -329,6 +345,7 @@ class WebKitGTKBackend : public LaufeyBackend {
   void CloseWindow(uint32_t window_id) override;
 
   void Navigate(uint32_t window_id, const std::string& url) override;
+  void OpenExternalURL(const std::string& url) override;
   void SetTitle(uint32_t window_id, const std::string& title) override;
   void ExecuteJs(uint32_t window_id, const std::string& script,
                  laufey_js_result_fn callback, void* callback_data) override;
@@ -679,6 +696,7 @@ void WebKitGTKBackend::CreateWindowEx(uint32_t window_id, int width, int height,
                      nullptr);
     g_signal_connect(webview, "load-changed", G_CALLBACK(on_load_changed),
                      GUINT_TO_POINTER(window_id));
+    g_signal_connect(webview, "create", G_CALLBACK(on_create), nullptr);
 
     WebKitSettings* wk_settings = webkit_web_view_get_settings(webview);
     webkit_settings_set_enable_developer_extras(wk_settings, TRUE);
@@ -745,6 +763,12 @@ void WebKitGTKBackend::Navigate(uint32_t window_id, const std::string& url) {
     if (state) {
       webkit_web_view_load_uri(state->webview, url.c_str());
     }
+  });
+}
+
+void WebKitGTKBackend::OpenExternalURL(const std::string& url) {
+  gtk_invoke_sync([&] {
+    g_app_info_launch_default_for_uri(url.c_str(), nullptr, nullptr);
   });
 }
 

--- a/webview/src/webview_macos.mm
+++ b/webview/src/webview_macos.mm
@@ -51,6 +51,7 @@ class WKWebViewBackend : public LaufeyBackend {
   void CloseWindow(uint32_t window_id) override;
 
   void Navigate(uint32_t window_id, const std::string& url) override;
+  void OpenExternalURL(const std::string& url) override;
   void SetTitle(uint32_t window_id, const std::string& title) override;
   void ExecuteJs(uint32_t window_id, const std::string& script,
                  laufey_js_result_fn callback, void* callback_data) override;
@@ -360,6 +361,21 @@ class MacSchemeExchange : public SchemeExchangeBase {
 @end
 
 @implementation LaufeyUIDelegate
+
+// `target="_blank"` and `window.open()` request a new browsing context, which
+// the Navigation API interceptor never sees. WKWebView has no popup support, so
+// route http(s) destinations to the OS browser and create no new webview.
+- (WKWebView*)webView:(WKWebView*)webView
+    createWebViewWithConfiguration:(WKWebViewConfiguration*)configuration
+               forNavigationAction:(WKNavigationAction*)navigationAction
+                    windowFeatures:(WKWindowFeatures*)windowFeatures {
+  NSURL* url = navigationAction.request.URL;
+  if (url && ([url.scheme isEqualToString:@"http"] ||
+              [url.scheme isEqualToString:@"https"])) {
+    [[NSWorkspace sharedWorkspace] openURL:url];
+  }
+  return nil;
+}
 
 - (void)webView:(WKWebView*)webView
     runJavaScriptAlertPanelWithMessage:(NSString*)message
@@ -916,6 +932,19 @@ void WKWebViewBackend::CloseWindow(uint32_t window_id) {
       if (!win)
         return;
       [win close];
+    }
+  });
+}
+
+void WKWebViewBackend::OpenExternalURL(const std::string& url) {
+  std::string urlCopy = url;
+  dispatch_async(dispatch_get_main_queue(), ^{
+    @autoreleasepool {
+      NSURL* nsurl =
+          [NSURL URLWithString:[NSString stringWithUTF8String:urlCopy.c_str()]];
+      if (nsurl) {
+        [[NSWorkspace sharedWorkspace] openURL:nsurl];
+      }
     }
   });
 }

--- a/webview/src/webview_windows.cc
+++ b/webview/src/webview_windows.cc
@@ -319,6 +319,7 @@ class WebView2Backend : public LaufeyBackend {
   void CloseWindow(uint32_t window_id) override;
 
   void Navigate(uint32_t window_id, const std::string& url) override;
+  void OpenExternalURL(const std::string& url) override;
   void SetTitle(uint32_t window_id, const std::string& title) override;
   void ExecuteJs(uint32_t window_id, const std::string& script,
                  laufey_js_result_fn callback, void* callback_data) override;
@@ -823,6 +824,31 @@ void WebView2Backend::OnEnvironmentReady(uint32_t window_id, HWND hwnd,
                     .Get(),
                 nullptr);
 
+            // `target="_blank"` / `window.open()` request a new window, which
+            // the Navigation API interceptor never sees. WebView2 would spawn a
+            // popup webview; instead route http(s) destinations to the OS
+            // browser and mark the request handled so no popup is created.
+            state->webview->add_NewWindowRequested(
+                Callback<ICoreWebView2NewWindowRequestedEventHandler>(
+                    [](ICoreWebView2* sender,
+                       ICoreWebView2NewWindowRequestedEventArgs* args)
+                        -> HRESULT {
+                      LPWSTR uriRaw = nullptr;
+                      args->get_Uri(&uriRaw);
+                      if (uriRaw) {
+                        if (wcsncmp(uriRaw, L"http://", 7) == 0 ||
+                            wcsncmp(uriRaw, L"https://", 8) == 0) {
+                          ShellExecuteW(nullptr, L"open", uriRaw, nullptr,
+                                        nullptr, SW_SHOWNORMAL);
+                        }
+                        CoTaskMemFree(uriRaw);
+                      }
+                      args->put_Handled(TRUE);
+                      return S_OK;
+                    })
+                    .Get(),
+                nullptr);
+
             // In-process app:// scheme: intercept requests and
             // bridge them to the runtime's memory transport. Only
             // wired up when the "app" scheme was actually registered
@@ -967,6 +993,12 @@ void WebView2Backend::Navigate(uint32_t window_id, const std::string& url) {
   } else {
     state->pending_url = wurl;
   }
+}
+
+void WebView2Backend::OpenExternalURL(const std::string& url) {
+  std::wstring wurl = Utf8ToWide(url);
+  ShellExecuteW(nullptr, L"open", wurl.c_str(), nullptr, nullptr,
+                SW_SHOWNORMAL);
 }
 
 void WebView2Backend::SetTitle(uint32_t window_id, const std::string& title) {


### PR DESCRIPTION
## Problem

Clicking an `http(s)` link to a different origin inside a webview replaced the app's view with the remote page instead of opening it in the user's browser. This affected every backend (CEF and the system WebView on all platforms) — there was no navigation interception anywhere.

## Approach

A single shared policy lives in `capi/include/laufey_external_links.h` and is injected into every page. It picks the best available mechanism at runtime:

- **Navigation API** (`window.navigation`) where present — CEF/Chromium and WebView2. Also catches `location.href = …`, form submits, etc.
- **Click-capture fallback** where it isn't — **WKWebView on macOS/iOS does not expose the Navigation API** (confirmed empirically; Safari has it, the embedded webview does not). Intercepts plain left clicks on `<a>` elements.

Exactly one runs, so a link is never handled twice. The listener cancels **cross-origin `http(s)`** navigations and calls a reserved bridge method `__laufeyOpenExternal`; **same-origin, fragment, and `laufey://`** navigations stay in the view.

Each backend intercepts the reserved method before dispatching to the runtime and opens the URL natively:

| Platform | Open primitive |
|---|---|
| macOS / iOS | `NSWorkspace openURL:` / `UIApplication openURL:` |
| Windows | `ShellExecuteW` |
| Linux | `g_app_info_launch_default_for_uri` |

`target="_blank"` / `window.open()` never reach the page-side listener, so they're handled by each backend's new-window hook (`OnBeforePopup`, `WKUIDelegate.createWebView`, WebKitGTK `create`, WebView2 `NewWindowRequested`) routed to the same primitive.

## Policy

Hardcoded by design: redirect only user-initiated, cross-origin `http(s)` navigations. Same-origin SPA routing, in-page fragments, and the app's own `laufey://` scheme stay in the view.

## Commits

1. `build(cef)` — pre-existing fix: ObjC++ sources were compiled at C++17 while CEF 149 headers need C++20 (the `cxx_std_20` interface feature only applies to CXX, not OBJCXX), so the CEF macOS build was already broken. Independent of the feature; called out separately for review.
2. `feat` — the feature across all backends.
3. `chore(example)` — demo links in the hello example.

## Testing

- Built and ran on **macOS** (both webview and CEF). Verified live in the hello example: external in-place link → opens in browser, app stays; `target="_blank"` → opens in browser; in-page fragment link → scrolls within the app, no navigation.
- Injected JS validated for syntax; click-fallback branching verified in a DOM simulation (external → opens, same-origin → stays, `_blank` → left for the native hook).
- All changed C/C++ files pass `clang-format`.

## Not covered here

- **Windows / Linux / iOS** edits follow each platform's standard API but were **not compiled or run** — only macOS was built locally.
- Engines without the Navigation API and without the click path (e.g. JS-driven `location.href` on old WKWebView) aren't redirected for non-click navigations; the click fallback covers the reported "clicked a link" case on those engines.