### PR TITLE
feat: window opacity and transparency APIs

### DIFF
--- a/backend-winit-common/src/lib.rs
+++ b/backend-winit-common/src/lib.rs
@@ -31,12 +31,13 @@ use winit::window::{Window, WindowLevel};
 // Must match `LAUFEY_API_VERSION` in capi/include/laufey.h (and capi/src/lib.rs).
 // Bumping this in lockstep with the capi is mandatory: the capi's `init_api`
 // rejects any backend whose reported `version` differs, and the vtable layout
-// below must match the v26 `laufey_backend_api`.
-pub const LAUFEY_API_VERSION: u32 = 26;
+// below must match the v28 `laufey_backend_api`.
+pub const LAUFEY_API_VERSION: u32 = 28;
 
 /// Creation-time window style flags (mirror `LAUFEY_WINDOW_FLAG_*` in laufey.h).
 pub const LAUFEY_WINDOW_FLAG_FRAMELESS: u32 = 1 << 0;
 pub const LAUFEY_WINDOW_FLAG_NO_ACTIVATE: u32 = 1 << 1;
+pub const LAUFEY_WINDOW_FLAG_TRANSPARENT: u32 = 1 << 4;
 
 #[allow(dead_code)]
 pub const LAUFEY_WINDOW_HANDLE_UNKNOWN: c_int = 0;
@@ -127,6 +128,13 @@ pub type LaufeyMoveFn = unsafe extern "C" fn(
   c_int,       // y
 );
 pub type LaufeyCloseRequestedFn = unsafe extern "C" fn(
+  *mut c_void, // user_data
+  u32,         // window_id
+);
+// Mirrors `laufey_page_load_fn` (API >= 27). The winit backend has no web
+// engine and never fires page-load events; the typedef exists only so the
+// `set_page_load_handler` vtable slot has the right signature.
+pub type LaufeyPageLoadFn = unsafe extern "C" fn(
   *mut c_void, // user_data
   u32,         // window_id
 );
@@ -317,6 +325,11 @@ pub struct LaufeyBackendApi {
       *mut c_void,
     ),
   >,
+  // Mirrors laufey.h: set_page_load_handler (API >= 27) sits between
+  // set_close_requested_handler and poll_js_calls.
+  pub set_page_load_handler: Option<
+    unsafe extern "C" fn(*mut c_void, Option<LaufeyPageLoadFn>, *mut c_void),
+  >,
   pub poll_js_calls: Option<unsafe extern "C" fn(*mut c_void)>,
   pub set_js_call_notify: Option<
     unsafe extern "C" fn(
@@ -496,6 +509,14 @@ pub struct LaufeyBackendApi {
       *mut c_void, // exchange
     ),
   >,
+
+  // --- Window opacity (API >= 28) ---
+  // winit exposes no runtime window-opacity API, so both pointers stay None;
+  // the embedder's set_opacity/get_opacity become no-ops (get returns 1.0).
+  // The fields MUST still be declared to keep the struct layout in sync with
+  // the v28 `laufey_backend_api` the capi reads through the backend's pointer.
+  pub set_window_opacity: Option<unsafe extern "C" fn(*mut c_void, u32, f64)>,
+  pub get_window_opacity: Option<unsafe extern "C" fn(*mut c_void, u32) -> f64>,
 }
 
 unsafe impl Send for LaufeyBackendApi {}
@@ -1087,6 +1108,7 @@ pub fn create_api_base() -> LaufeyBackendApi {
     set_resize_handler: None,
     set_move_handler: None,
     set_close_requested_handler: None,
+    set_page_load_handler: None,
     poll_js_calls: None,
     set_js_call_notify: None,
     set_application_menu: None,
@@ -1119,6 +1141,9 @@ pub fn create_api_base() -> LaufeyBackendApi {
     scheme_response_begin: None,
     scheme_response_write: None,
     scheme_response_finish: None,
+    // Window opacity (API >= 28): winit has no runtime opacity API.
+    set_window_opacity: None,
+    get_window_opacity: None,
   }
 }
 
@@ -2897,6 +2922,13 @@ pub fn apply_pending_attrs(
   if flags & LAUFEY_WINDOW_FLAG_NO_ACTIVATE != 0 {
     // Don't activate / take focus when first shown.
     attrs = attrs.with_active(false);
+  }
+  if flags & LAUFEY_WINDOW_FLAG_TRANSPARENT != 0 {
+    // Transparent background so anything the window draws with alpha < 1
+    // composites against the desktop. (winit has no web engine of its own,
+    // but the flag is honored so embedders driving their own surface get a
+    // transparent framebuffer.)
+    attrs = attrs.with_transparent(true);
   }
   attrs
 }

--- a/capi/include/laufey.h
+++ b/capi/include/laufey.h
@@ -11,7 +11,7 @@
 extern "C" {
 #endif
 
-#define LAUFEY_API_VERSION 27
+#define LAUFEY_API_VERSION 28
 
 // Window handle types for get_window_handle_type
 #define LAUFEY_WINDOW_HANDLE_UNKNOWN 0
@@ -43,10 +43,25 @@ extern "C" {
 // so the user never sees the empty/black initial webview frame — particularly
 // important on Wayland, where the compositor only ever presents committed
 // buffers and the pre-load frame shows as solid black. API >= 27.
+//
+// TRANSPARENT creates the window with a transparent background so the alpha
+// channel of the web content composites against whatever is behind the window
+// (Electron `transparent: true`, Tauri `transparent: true`). The OS window is
+// made non-opaque and the web engine is told not to paint an opaque backdrop,
+// so any page region the document leaves transparent (e.g. `background:
+// transparent` on the root) shows the desktop / windows underneath. Pair it
+// with FRAMELESS for the common borderless-translucent look. This is distinct
+// from `set_window_opacity`, which fades the whole window (chrome included) by
+// a uniform factor; TRANSPARENT instead honors the page's own per-pixel alpha.
+// Must be decided at creation time. Supported by the system-WebView backend on
+// macOS and Linux (WebKitGTK) and by the Winit backend. The Windows WebView2
+// and CEF backends paint an opaque window background in windowed mode and
+// ignore this flag. API >= 28.
 #define LAUFEY_WINDOW_FLAG_FRAMELESS (1u << 0)
 #define LAUFEY_WINDOW_FLAG_NO_ACTIVATE (1u << 1)
 #define LAUFEY_WINDOW_FLAG_TRANSPARENT_TITLEBAR (1u << 2)
 #define LAUFEY_WINDOW_FLAG_HIDDEN (1u << 3)
+#define LAUFEY_WINDOW_FLAG_TRANSPARENT (1u << 4)
 
 typedef struct laufey_backend_api laufey_backend_api_t;
 
@@ -676,6 +691,25 @@ struct laufey_backend_api {
   // is invalid. Call exactly once per exchange (including after a cancel).
   void (*scheme_response_finish)(void* backend_data,
                                  laufey_scheme_exchange_t* exchange);
+
+  // --- Window opacity (API >= 28) --------------------------------------------
+  //
+  // Set the window's overall opacity as a uniform factor in [0.0, 1.0], where
+  // 1.0 is fully opaque (the default) and 0.0 is fully transparent. Unlike
+  // LAUFEY_WINDOW_FLAG_TRANSPARENT (which honors the page's per-pixel alpha),
+  // this fades the *entire* window — web content and native chrome alike — by
+  // the same amount, like CSS `opacity` on the whole window. Values are clamped
+  // to [0.0, 1.0]. macOS: NSWindow.alphaValue. Windows: a layered window with
+  // SetLayeredWindowAttributes(LWA_ALPHA). Linux: gtk_widget_set_opacity. The
+  // Winit backend has no window-opacity API and leaves this NULL. Backends
+  // added before API version 28 also leave it NULL; callers must null-check.
+  void (*set_window_opacity)(void* backend_data, uint32_t window_id,
+                             double opacity);
+
+  // Return the window's current opacity in [0.0, 1.0]. Returns 1.0 if the id is
+  // unknown or the backend can't report it. NULL on backends older than API
+  // version 28.
+  double (*get_window_opacity)(void* backend_data, uint32_t window_id);
 };
 
 #ifdef __cplusplus

--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -29,7 +29,7 @@ pub use mouse::*;
 /// (`github.com/denoland/laufey/releases/tag/v{VERSION}`).
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-pub const LAUFEY_API_VERSION: u32 = 27;
+pub const LAUFEY_API_VERSION: u32 = 28;
 
 /// Creation-time window style flags for [`Window::new_with_options`].
 /// Mirror the `LAUFEY_WINDOW_FLAG_*` constants in `laufey.h`.
@@ -37,6 +37,7 @@ pub const LAUFEY_WINDOW_FLAG_FRAMELESS: u32 = 1 << 0;
 pub const LAUFEY_WINDOW_FLAG_NO_ACTIVATE: u32 = 1 << 1;
 pub const LAUFEY_WINDOW_FLAG_TRANSPARENT_TITLEBAR: u32 = 1 << 2;
 pub const LAUFEY_WINDOW_FLAG_HIDDEN: u32 = 1 << 3;
+pub const LAUFEY_WINDOW_FLAG_TRANSPARENT: u32 = 1 << 4;
 
 pub const LAUFEY_WINDOW_HANDLE_UNKNOWN: i32 = 0;
 pub const LAUFEY_WINDOW_HANDLE_APPKIT: i32 = 1;
@@ -685,6 +686,15 @@ pub struct WindowOptions {
   /// handler so the first reveal happens only once content has painted, avoiding
   /// the empty/black initial frame (most visible on Wayland).
   pub hidden: bool,
+  /// Give the window a transparent background so the web content's own alpha
+  /// composites against whatever is behind the window. Any region the page
+  /// leaves transparent (e.g. `background: transparent` on the root element)
+  /// shows the desktop through it. Often combined with `frameless` for a
+  /// borderless translucent look. Distinct from [`Window::set_opacity`], which
+  /// uniformly fades the whole window. Supported by the system-WebView backend
+  /// on macOS and Linux and by the Winit backend; ignored by the Windows
+  /// WebView2 and CEF backends, which paint an opaque window background.
+  pub transparent: bool,
 }
 
 impl WindowOptions {
@@ -701,6 +711,9 @@ impl WindowOptions {
     }
     if self.hidden {
       flags |= LAUFEY_WINDOW_FLAG_HIDDEN;
+    }
+    if self.transparent {
+      flags |= LAUFEY_WINDOW_FLAG_TRANSPARENT;
     }
     flags
   }
@@ -852,6 +865,37 @@ impl Window {
       unsafe { f(api.backend_data, self.id) }
     } else {
       false
+    }
+  }
+
+  /// Builder form of [`Window::set_opacity`].
+  pub fn opacity(self, opacity: f64) -> Self {
+    self.set_opacity(opacity);
+    self
+  }
+
+  /// Set the window's overall opacity, a uniform factor in `[0.0, 1.0]` where
+  /// `1.0` is fully opaque (the default) and `0.0` is fully transparent. This
+  /// fades the entire window — web content and native chrome alike — like CSS
+  /// `opacity`. It is distinct from [`WindowOptions::transparent`], which makes
+  /// the background transparent while honoring the page's own per-pixel alpha.
+  /// Out-of-range values are clamped. No-op on backends without opacity support
+  /// (e.g. the Winit backend).
+  pub fn set_opacity(&self, opacity: f64) {
+    let api = api();
+    if let Some(f) = api.set_window_opacity {
+      unsafe { f(api.backend_data, self.id, opacity.clamp(0.0, 1.0)) };
+    }
+  }
+
+  /// Get the window's current opacity in `[0.0, 1.0]`. Returns `1.0` when the
+  /// backend does not report opacity.
+  pub fn get_opacity(&self) -> f64 {
+    let api = api();
+    if let Some(f) = api.get_window_opacity {
+      unsafe { f(api.backend_data, self.id) }
+    } else {
+      1.0
     }
   }
 
@@ -2789,12 +2833,29 @@ mod tests {
     );
     assert_eq!(
       WindowOptions {
+        transparent: true,
+        ..Default::default()
+      }
+      .to_flags(),
+      LAUFEY_WINDOW_FLAG_TRANSPARENT
+    );
+    assert_eq!(
+      WindowOptions {
         frameless: true,
         no_activate: true,
         ..Default::default()
       }
       .to_flags(),
       LAUFEY_WINDOW_FLAG_FRAMELESS | LAUFEY_WINDOW_FLAG_NO_ACTIVATE
+    );
+    assert_eq!(
+      WindowOptions {
+        frameless: true,
+        transparent: true,
+        ..Default::default()
+      }
+      .to_flags(),
+      LAUFEY_WINDOW_FLAG_FRAMELESS | LAUFEY_WINDOW_FLAG_TRANSPARENT
     );
   }
 

--- a/cef/src/main_linux.cc
+++ b/cef/src/main_linux.cc
@@ -492,6 +492,57 @@ bool IsLinuxWindowResizable(unsigned long xid) {
 #endif
 }
 
+void SetLinuxWindowOpacity(unsigned long xid, double opacity) {
+#ifdef GDK_WINDOWING_X11
+  GdkDisplay* gdk_display = gdk_display_get_default();
+  if (!gdk_display || !GDK_IS_X11_DISPLAY(gdk_display))
+    return;
+  Display* dpy = GDK_DISPLAY_XDISPLAY(gdk_display);
+
+  // _NET_WM_WINDOW_OPACITY is a CARDINAL where 0xffffffff is fully opaque and
+  // 0 fully transparent; compositing WMs scale the whole window by it.
+  Atom net_wm_opacity = XInternAtom(dpy, "_NET_WM_WINDOW_OPACITY", False);
+  if (opacity >= 1.0) {
+    // Fully opaque: drop the hint so the WM treats the window normally.
+    XDeleteProperty(dpy, xid, net_wm_opacity);
+  } else {
+    unsigned long value = (unsigned long)(opacity * 0xffffffffUL);
+    XChangeProperty(dpy, xid, net_wm_opacity, XA_CARDINAL, 32, PropModeReplace,
+                    reinterpret_cast<unsigned char*>(&value), 1);
+  }
+  XFlush(dpy);
+#endif
+}
+
+double GetLinuxWindowOpacity(unsigned long xid) {
+#ifdef GDK_WINDOWING_X11
+  GdkDisplay* gdk_display = gdk_display_get_default();
+  if (!gdk_display || !GDK_IS_X11_DISPLAY(gdk_display))
+    return 1.0;
+  Display* dpy = GDK_DISPLAY_XDISPLAY(gdk_display);
+
+  Atom net_wm_opacity = XInternAtom(dpy, "_NET_WM_WINDOW_OPACITY", False);
+  Atom actual_type = None;
+  int actual_format = 0;
+  unsigned long nitems = 0, bytes_after = 0;
+  unsigned char* prop = nullptr;
+  double result = 1.0;
+  if (XGetWindowProperty(dpy, xid, net_wm_opacity, 0, 1, False, XA_CARDINAL,
+                         &actual_type, &actual_format, &nitems, &bytes_after,
+                         &prop) == Success) {
+    if (prop && nitems >= 1 && actual_format == 32) {
+      unsigned long value = *reinterpret_cast<unsigned long*>(prop);
+      result = (double)value / (double)0xffffffffUL;
+    }
+    if (prop)
+      XFree(prop);
+  }
+  return result;
+#else
+  return 1.0;
+#endif
+}
+
 void MonitorLinuxWindowEvents(unsigned long xid) {
 #ifdef GDK_WINDOWING_X11
   if (!g_monitor_display)

--- a/cef/src/runtime_loader.cc
+++ b/cef/src/runtime_loader.cc
@@ -412,6 +412,82 @@ static bool Backend_IsAlwaysOnTop(void* data, uint32_t window_id) {
   return result;
 }
 
+static void Backend_SetWindowOpacity(void* data, uint32_t window_id,
+                                     double opacity) {
+  if (opacity < 0.0)
+    opacity = 0.0;
+  if (opacity > 1.0)
+    opacity = 1.0;
+  RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);
+  CefRefPtr<CefBrowser> browser = loader->GetBrowserForWindow(window_id);
+  if (browser) {
+    CefPostTask(TID_UI,
+                base::BindOnce(
+                    [](CefRefPtr<CefBrowser> b, double o) {
+                      auto browser_view = CefBrowserView::GetForBrowser(b);
+                      if (!browser_view)
+                        return;
+                      auto window = browser_view->GetWindow();
+                      if (!window)
+                        return;
+#ifdef _WIN32
+                      HWND hwnd = window->GetWindowHandle();
+                      LONG ex = GetWindowLong(hwnd, GWL_EXSTYLE);
+                      if (o >= 1.0) {
+                        if (ex & WS_EX_LAYERED) {
+                          SetWindowLong(hwnd, GWL_EXSTYLE, ex & ~WS_EX_LAYERED);
+                          RedrawWindow(hwnd, nullptr, nullptr,
+                                       RDW_ERASE | RDW_INVALIDATE | RDW_FRAME |
+                                           RDW_ALLCHILDREN);
+                        }
+                      } else {
+                        if (!(ex & WS_EX_LAYERED))
+                          SetWindowLong(hwnd, GWL_EXSTYLE, ex | WS_EX_LAYERED);
+                        SetLayeredWindowAttributes(
+                            hwnd, 0, (BYTE)(o * 255.0 + 0.5), LWA_ALPHA);
+                      }
+#elif defined(__APPLE__)
+                      SetNSWindowOpacity(window->GetWindowHandle(), o);
+#elif defined(__linux__)
+                      SetLinuxWindowOpacity(window->GetWindowHandle(), o);
+#endif
+                    },
+                    browser, opacity));
+  }
+}
+
+static double Backend_GetWindowOpacity(void* data, uint32_t window_id) {
+  RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);
+  CefRefPtr<CefBrowser> browser = loader->GetBrowserForWindow(window_id);
+  double result = 1.0;
+  if (browser) {
+    cef_invoke_sync([&] {
+      auto browser_view = CefBrowserView::GetForBrowser(browser);
+      if (!browser_view)
+        return;
+      auto window = browser_view->GetWindow();
+      if (!window)
+        return;
+#ifdef _WIN32
+      HWND hwnd = window->GetWindowHandle();
+      if (!(GetWindowLong(hwnd, GWL_EXSTYLE) & WS_EX_LAYERED))
+        return;
+      BYTE alpha = 255;
+      DWORD flags = 0;
+      if (GetLayeredWindowAttributes(hwnd, nullptr, &alpha, &flags) &&
+          (flags & LWA_ALPHA)) {
+        result = alpha / 255.0;
+      }
+#elif defined(__APPLE__)
+      result = GetNSWindowOpacity(window->GetWindowHandle());
+#elif defined(__linux__)
+      result = GetLinuxWindowOpacity(window->GetWindowHandle());
+#endif
+    });
+  }
+  return result;
+}
+
 static bool Backend_IsVisible(void* data, uint32_t window_id) {
   RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);
   CefRefPtr<CefBrowser> browser = loader->GetBrowserForWindow(window_id);
@@ -1361,6 +1437,8 @@ void RuntimeLoader::InitializeBackendApi() {
   backend_api_.is_resizable = Backend_IsResizable;
   backend_api_.set_always_on_top = Backend_SetAlwaysOnTop;
   backend_api_.is_always_on_top = Backend_IsAlwaysOnTop;
+  backend_api_.set_window_opacity = Backend_SetWindowOpacity;
+  backend_api_.get_window_opacity = Backend_GetWindowOpacity;
   backend_api_.is_visible = Backend_IsVisible;
   backend_api_.show = Backend_Show;
   backend_api_.hide = Backend_Hide;

--- a/cef/src/runtime_loader.h
+++ b/cef/src/runtime_loader.h
@@ -456,6 +456,9 @@ void RegisterNSWindowForCefHandle(void* cef_handle, uint32_t window_id);
 void UnregisterNSWindowForCefHandle(void* cef_handle);
 void SetNSWindowResizable(void* cef_handle, bool resizable);
 bool IsNSWindowResizable(void* cef_handle);
+// Overall window opacity in [0.0, 1.0] via NSWindow.alphaValue.
+void SetNSWindowOpacity(void* cef_handle, double opacity);
+double GetNSWindowOpacity(void* cef_handle);
 // Reconfigure the window backing a CEF handle to behave as a floating,
 // non-activating utility panel (used for tray popovers): floats above
 // normal windows, joins all spaces, and doesn't steal focus from the
@@ -481,6 +484,10 @@ void ConfigureWin32WindowAsPanel(void* hwnd);
 void MonitorLinuxWindowEvents(unsigned long xid);
 void SetLinuxWindowResizable(unsigned long xid, bool resizable);
 bool IsLinuxWindowResizable(unsigned long xid);
+// Overall window opacity in [0.0, 1.0] via the _NET_WM_WINDOW_OPACITY hint
+// (honored by compositing window managers). Implemented in main_linux.cc.
+void SetLinuxWindowOpacity(unsigned long xid, double opacity);
+double GetLinuxWindowOpacity(unsigned long xid);
 // Mark the X11 window as a utility/panel window (_NET_WM_WINDOW_TYPE_UTILITY,
 // skip taskbar/pager) so the WM treats it as an auxiliary panel that doesn't
 // take part in normal focus/taskbar handling. Implemented in main_linux.cc.

--- a/cef/src/runtime_loader_mac.mm
+++ b/cef/src/runtime_loader_mac.mm
@@ -44,6 +44,23 @@ bool IsNSWindowResizable(void* cef_handle) {
   return true;
 }
 
+void SetNSWindowOpacity(void* cef_handle, double opacity) {
+  NSView* view = (__bridge NSView*)cef_handle;
+  NSWindow* nswindow = [view window];
+  if (nswindow) {
+    [nswindow setAlphaValue:(CGFloat)opacity];
+  }
+}
+
+double GetNSWindowOpacity(void* cef_handle) {
+  NSView* view = (__bridge NSView*)cef_handle;
+  NSWindow* nswindow = [view window];
+  if (nswindow) {
+    return (double)[nswindow alphaValue];
+  }
+  return 1.0;
+}
+
 void ConfigureNSWindowAsPanelForCefHandle(void* cef_handle) {
   NSView* view = (__bridge NSView*)cef_handle;
   NSWindow* nswindow = [view window];

--- a/docs/c-abi.md
+++ b/docs/c-abi.md
@@ -6,7 +6,7 @@ It defines the boundary between a **backend** (a native executable embedding a
 browser engine) and a **runtime** (a shared library holding the application
 logic). The backend implements the ABI; the runtime consumes it.
 
-`LAUFEY_API_VERSION` (currently `26`) versions the contract. The `version` field
+`LAUFEY_API_VERSION` (currently `28`) versions the contract. The `version` field
 on the API table lets a runtime detect the backend's vintage and avoid calling
 function pointers a backend predates (older backends leave new pointers `NULL`).
 
@@ -43,10 +43,12 @@ hand-rolled vtable with no global state. Windows are referenced by an opaque
 The pointers group into:
 
 - **Window lifecycle** — `create_window`, `create_window_ex` (style flags, see
-  `LAUFEY_WINDOW_FLAG_*`), `close_window`, `navigate`, `set_title`,
+  `LAUFEY_WINDOW_FLAG_*`, including `LAUFEY_WINDOW_FLAG_TRANSPARENT` for a
+  transparent background), `close_window`, `navigate`, `set_title`,
   size/position get+set, `set_resizable`/`is_resizable`,
-  `set_always_on_top`/`is_always_on_top`, `show`/`hide`/`is_visible`, `focus`,
-  `quit`, `post_ui_task`.
+  `set_always_on_top`/`is_always_on_top`,
+  `set_window_opacity`/`get_window_opacity` (whole-window alpha, API ≥ 28),
+  `show`/`hide`/`is_visible`, `focus`, `quit`, `post_ui_task`.
 - **Value marshalling** — the `value_*` family (below).
 - **JavaScript interop** — `set_js_call_handler`, `js_call_respond`,
   `invoke_js_callback`, `release_js_callback`, `execute_js`, `set_js_namespace`,

--- a/docs/window-management.md
+++ b/docs/window-management.md
@@ -1,7 +1,7 @@
 # Window management
 
 Every laufey application is built around one or more native windows. A `Window`
-controls its title, size, position, resizable and always-on-top flags,
+controls its title, size, position, resizable and always-on-top flags, opacity,
 visibility, and focus. The type is a builder, so you can configure a window
 fluently when you create it, and each property also has a plain setter you can
 call later while the window is open.
@@ -13,6 +13,7 @@ let win = Window::new(800, 600)
   .title("My App")
   .position(100, 100)
   .resizable(true)
+  .opacity(0.95)
   .load("index.html"); // or .navigate("https://example.com")
 
 win.set_size(1024, 768);
@@ -23,9 +24,49 @@ win.hide();
 
 A few properties can only be chosen when the operating system creates the window
 and cannot be changed afterwards: whether the window is frameless (drawn without
-operating-system chrome) and whether it is a non-activating panel that does not
-steal keyboard focus. You set those through `Window::new_with_options`.
-Everything else is a live setter. All positions and sizes are expressed in
-density-independent pixels with the origin at the top-left of the screen. The
-Winit backend can create and manage windows, but because it has no web engine it
-cannot navigate to a URL or execute JavaScript.
+operating-system chrome), whether it is a non-activating panel that does not
+steal keyboard focus, and whether it has a transparent background. You set those
+through `Window::new_with_options`. Everything else is a live setter. All
+positions and sizes are expressed in density-independent pixels with the origin
+at the top-left of the screen. The Winit backend can create and manage windows,
+but because it has no web engine it cannot navigate to a URL or execute
+JavaScript.
+
+## Opacity and transparency
+
+These are two distinct things:
+
+- **Opacity** (`Window::opacity` / `set_opacity` / `get_opacity`) fades the
+  _entire_ window — web content and native chrome alike — by a uniform factor in
+  `0.0..=1.0`, where `1.0` is fully opaque (the default), like CSS `opacity` on
+  the whole window. It is a live setter you can animate at runtime. The web
+  backends implement it on every desktop platform (macOS `NSWindow.alphaValue`,
+  Windows layered-window alpha, Linux `gtk_widget_set_opacity`). The Winit
+  backend has no opacity API, so the call is a no-op there and `get_opacity`
+  returns `1.0`.
+
+  ```rust
+  win.set_opacity(0.8); // 80% opaque
+  ```
+
+- **Transparency** (`WindowOptions::transparent`) gives the window a transparent
+  _background_ so the web content's own alpha composites against whatever is
+  behind the window. Any region the page leaves transparent (e.g. a
+  `transparent` root background) shows the desktop through it. This must be
+  chosen at creation time and is commonly paired with `frameless`.
+
+  ```rust
+  use laufey::{Window, WindowOptions};
+
+  let win = Window::new_with_options(
+    400,
+    300,
+    WindowOptions { frameless: true, transparent: true, ..Default::default() },
+  )
+  .load("index.html");
+  ```
+
+  Transparency is supported by the system-WebView backend on macOS and on Linux
+  (WebKitGTK, on a compositing window manager), and by the Winit backend. It is
+  not supported by the Windows WebView2 backend or the CEF backend, which paint
+  an opaque window background; the flag is ignored there.

--- a/webview/src/runtime_loader.cc
+++ b/webview/src/runtime_loader.cc
@@ -205,6 +205,24 @@ static bool Backend_IsAlwaysOnTop(void* data, uint32_t window_id) {
   return false;
 }
 
+static void Backend_SetWindowOpacity(void* data, uint32_t window_id,
+                                     double opacity) {
+  RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);
+  LaufeyBackend* backend = loader->GetBackend();
+  if (backend) {
+    backend->SetWindowOpacity(window_id, opacity);
+  }
+}
+
+static double Backend_GetWindowOpacity(void* data, uint32_t window_id) {
+  RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);
+  LaufeyBackend* backend = loader->GetBackend();
+  if (backend) {
+    return backend->GetWindowOpacity(window_id);
+  }
+  return 1.0;
+}
+
 static bool Backend_IsVisible(void* data, uint32_t window_id) {
   RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);
   LaufeyBackend* backend = loader->GetBackend();
@@ -665,6 +683,8 @@ void RuntimeLoader::InitializeBackendApi() {
   backend_api_.is_resizable = Backend_IsResizable;
   backend_api_.set_always_on_top = Backend_SetAlwaysOnTop;
   backend_api_.is_always_on_top = Backend_IsAlwaysOnTop;
+  backend_api_.set_window_opacity = Backend_SetWindowOpacity;
+  backend_api_.get_window_opacity = Backend_GetWindowOpacity;
   backend_api_.is_visible = Backend_IsVisible;
   backend_api_.show = Backend_Show;
   backend_api_.hide = Backend_Hide;

--- a/webview/src/runtime_loader.h
+++ b/webview/src/runtime_loader.h
@@ -379,6 +379,13 @@ class LaufeyBackend {
   virtual bool IsResizable(uint32_t window_id) = 0;
   virtual void SetAlwaysOnTop(uint32_t window_id, bool always_on_top) = 0;
   virtual bool IsAlwaysOnTop(uint32_t window_id) = 0;
+  // Overall window opacity in [0.0, 1.0] (1.0 == fully opaque). Fades the whole
+  // window uniformly, unlike LAUFEY_WINDOW_FLAG_TRANSPARENT. Default no-op /
+  // reports fully opaque; platform backends override.
+  virtual void SetWindowOpacity(uint32_t /*window_id*/, double /*opacity*/) {}
+  virtual double GetWindowOpacity(uint32_t /*window_id*/) {
+    return 1.0;
+  }
   virtual bool IsVisible(uint32_t window_id) = 0;
   virtual void Show(uint32_t window_id) = 0;
   virtual void Hide(uint32_t window_id) = 0;

--- a/webview/src/webview_linux.cc
+++ b/webview/src/webview_linux.cc
@@ -358,6 +358,8 @@ class WebKitGTKBackend : public LaufeyBackend {
   bool IsResizable(uint32_t window_id) override;
   void SetAlwaysOnTop(uint32_t window_id, bool always_on_top) override;
   bool IsAlwaysOnTop(uint32_t window_id) override;
+  void SetWindowOpacity(uint32_t window_id, double opacity) override;
+  double GetWindowOpacity(uint32_t window_id) override;
   bool IsVisible(uint32_t window_id) override;
   void Show(uint32_t window_id) override;
   void Hide(uint32_t window_id) override;
@@ -641,6 +643,17 @@ void WebKitGTKBackend::CreateWindowEx(uint32_t window_id, int width, int height,
     if (flags & LAUFEY_WINDOW_FLAG_FRAMELESS) {
       gtk_window_set_decorated(GTK_WINDOW(window), FALSE);
     }
+    bool transparent = (flags & LAUFEY_WINDOW_FLAG_TRANSPARENT) != 0;
+    if (transparent) {
+      // Give the toplevel an RGBA visual (must be set before realization) so
+      // the compositor blends the window's alpha. Requires a compositing WM.
+      GdkScreen* screen = gtk_widget_get_screen(window);
+      GdkVisual* rgba = gdk_screen_get_rgba_visual(screen);
+      if (rgba) {
+        gtk_widget_set_visual(window, rgba);
+      }
+      gtk_widget_set_app_paintable(window, TRUE);
+    }
     if (flags & LAUFEY_WINDOW_FLAG_NO_ACTIVATE) {
       // Treat as a utility/panel window: out of taskbar & pager, and don't
       // grab focus when shown (the GTK equivalent of a non-activating panel).
@@ -700,6 +713,13 @@ void WebKitGTKBackend::CreateWindowEx(uint32_t window_id, int width, int height,
 
     WebKitSettings* wk_settings = webkit_web_view_get_settings(webview);
     webkit_settings_set_enable_developer_extras(wk_settings, TRUE);
+
+    if (transparent) {
+      // Let the page's own alpha show through the webview (any region the
+      // document leaves transparent composites against the desktop).
+      GdkRGBA clear = {0.0, 0.0, 0.0, 0.0};
+      webkit_web_view_set_background_color(webview, &clear);
+    }
 
     std::string initScript = BuildInitScript(
         RuntimeLoader::GetInstance()->GetJsNamespace(),
@@ -971,6 +991,32 @@ bool WebKitGTKBackend::IsAlwaysOnTop(uint32_t window_id) {
         GdkWindowState wstate = gdk_window_get_state(gdk_window);
         result = (wstate & GDK_WINDOW_STATE_ABOVE) != 0;
       }
+    }
+  });
+  return result;
+}
+
+void WebKitGTKBackend::SetWindowOpacity(uint32_t window_id, double opacity) {
+  if (opacity < 0.0)
+    opacity = 0.0;
+  if (opacity > 1.0)
+    opacity = 1.0;
+  gtk_invoke_sync([&] {
+    std::lock_guard<std::mutex> lock(windows_mutex_);
+    auto* state = GetWindow(window_id);
+    if (state) {
+      gtk_widget_set_opacity(state->window, opacity);
+    }
+  });
+}
+
+double WebKitGTKBackend::GetWindowOpacity(uint32_t window_id) {
+  double result = 1.0;
+  gtk_invoke_sync([&] {
+    std::lock_guard<std::mutex> lock(windows_mutex_);
+    auto* state = GetWindow(window_id);
+    if (state) {
+      result = gtk_widget_get_opacity(state->window);
     }
   });
   return result;

--- a/webview/src/webview_macos.mm
+++ b/webview/src/webview_macos.mm
@@ -64,6 +64,8 @@ class WKWebViewBackend : public LaufeyBackend {
   bool IsResizable(uint32_t window_id) override;
   void SetAlwaysOnTop(uint32_t window_id, bool always_on_top) override;
   bool IsAlwaysOnTop(uint32_t window_id) override;
+  void SetWindowOpacity(uint32_t window_id, double opacity) override;
+  double GetWindowOpacity(uint32_t window_id) override;
   bool IsVisible(uint32_t window_id) override;
   void Show(uint32_t window_id) override;
   void Hide(uint32_t window_id) override;
@@ -743,6 +745,7 @@ void WKWebViewBackend::CreateWindowEx(uint32_t window_id, int width, int height,
 
       bool frameless = (flags & LAUFEY_WINDOW_FLAG_FRAMELESS) != 0;
       bool no_activate = (flags & LAUFEY_WINDOW_FLAG_NO_ACTIVATE) != 0;
+      bool transparent = (flags & LAUFEY_WINDOW_FLAG_TRANSPARENT) != 0;
 
       NSRect frame = NSMakeRect(0, 0, width, height);
       NSWindowStyleMask style = NSWindowStyleMaskClosable |
@@ -830,6 +833,22 @@ void WKWebViewBackend::CreateWindowEx(uint32_t window_id, int width, int height,
           [[LaufeyNavigationDelegate alloc] init];
       navDelegate.windowId = window_id;
       webview.navigationDelegate = navDelegate;
+
+      if (transparent) {
+        // Make the window non-opaque with a clear backdrop and stop the
+        // WKWebView from painting its own opaque background, so any region the
+        // page leaves transparent shows whatever is behind the window.
+        [window setOpaque:NO];
+        [window setBackgroundColor:[NSColor clearColor]];
+        // `drawsBackground` is an undocumented but long-stable WKWebView
+        // property; KVC keeps us off the private @interface.
+        @try {
+          [webview setValue:@NO forKey:@"drawsBackground"];
+        } @catch (NSException*) {
+          // Older/newer WebKit without the key: fall back to a clear layer.
+        }
+      }
+
       [window setContentView:webview];
 
       RegisterNSWindow(window, window_id);
@@ -1216,6 +1235,34 @@ bool WKWebViewBackend::IsAlwaysOnTop(uint32_t window_id) {
     auto* state = GetWindow(window_id);
     if (state) {
       result = [state->window level] >= NSFloatingWindowLevel;
+    }
+  });
+  return result;
+}
+
+void WKWebViewBackend::SetWindowOpacity(uint32_t window_id, double opacity) {
+  if (opacity < 0.0)
+    opacity = 0.0;
+  if (opacity > 1.0)
+    opacity = 1.0;
+  dispatch_async(dispatch_get_main_queue(), ^{
+    @autoreleasepool {
+      std::lock_guard<std::mutex> lock(windows_mutex_);
+      auto* state = GetWindow(window_id);
+      if (state) {
+        [state->window setAlphaValue:(CGFloat)opacity];
+      }
+    }
+  });
+}
+
+double WKWebViewBackend::GetWindowOpacity(uint32_t window_id) {
+  __block double result = 1.0;
+  dispatch_sync(dispatch_get_main_queue(), ^{
+    std::lock_guard<std::mutex> lock(windows_mutex_);
+    auto* state = GetWindow(window_id);
+    if (state) {
+      result = (double)[state->window alphaValue];
     }
   });
   return result;

--- a/webview/src/webview_windows.cc
+++ b/webview/src/webview_windows.cc
@@ -332,6 +332,8 @@ class WebView2Backend : public LaufeyBackend {
   bool IsResizable(uint32_t window_id) override;
   void SetAlwaysOnTop(uint32_t window_id, bool always_on_top) override;
   bool IsAlwaysOnTop(uint32_t window_id) override;
+  void SetWindowOpacity(uint32_t window_id, double opacity) override;
+  double GetWindowOpacity(uint32_t window_id) override;
   bool IsVisible(uint32_t window_id) override;
   void Show(uint32_t window_id) override;
   void Hide(uint32_t window_id) override;
@@ -1150,6 +1152,49 @@ bool WebView2Backend::IsAlwaysOnTop(uint32_t window_id) {
   auto* state = GetWindow(window_id);
   return state ? (GetWindowLong(state->hwnd, GWL_EXSTYLE) & WS_EX_TOPMOST) != 0
                : false;
+}
+
+void WebView2Backend::SetWindowOpacity(uint32_t window_id, double opacity) {
+  if (opacity < 0.0)
+    opacity = 0.0;
+  if (opacity > 1.0)
+    opacity = 1.0;
+  std::lock_guard<std::mutex> lock(windows_mutex_);
+  auto* state = GetWindow(window_id);
+  if (!state)
+    return;
+  LONG ex = GetWindowLong(state->hwnd, GWL_EXSTYLE);
+  if (opacity >= 1.0) {
+    // Fully opaque: drop the layered style so the window renders on the normal
+    // (non-redirected) path with no per-window alpha overhead.
+    if (ex & WS_EX_LAYERED) {
+      SetWindowLong(state->hwnd, GWL_EXSTYLE, ex & ~WS_EX_LAYERED);
+      RedrawWindow(state->hwnd, nullptr, nullptr,
+                   RDW_ERASE | RDW_INVALIDATE | RDW_FRAME | RDW_ALLCHILDREN);
+    }
+    return;
+  }
+  if (!(ex & WS_EX_LAYERED)) {
+    SetWindowLong(state->hwnd, GWL_EXSTYLE, ex | WS_EX_LAYERED);
+  }
+  SetLayeredWindowAttributes(state->hwnd, 0, (BYTE)(opacity * 255.0 + 0.5),
+                             LWA_ALPHA);
+}
+
+double WebView2Backend::GetWindowOpacity(uint32_t window_id) {
+  std::lock_guard<std::mutex> lock(windows_mutex_);
+  auto* state = GetWindow(window_id);
+  if (!state)
+    return 1.0;
+  if (!(GetWindowLong(state->hwnd, GWL_EXSTYLE) & WS_EX_LAYERED))
+    return 1.0;
+  BYTE alpha = 255;
+  DWORD flags = 0;
+  if (GetLayeredWindowAttributes(state->hwnd, nullptr, &alpha, &flags) &&
+      (flags & LWA_ALPHA)) {
+    return alpha / 255.0;
+  }
+  return 1.0;
 }
 
 bool WebView2Backend::IsVisible(uint32_t window_id) {


### PR DESCRIPTION
Implements window opacity/transparency support (requested in denoland/deno#35583).

These are two distinct features, both added here (laufey API version bumped 27 → 28):

## Window opacity
A live setter that fades the **whole** window — chrome and web content alike — by a uniform factor in `0.0..=1.0`, like CSS `opacity` on the window.

- ABI: `set_window_opacity` / `get_window_opacity`
- Rust: `Window::opacity()` builder, `set_opacity()`, `get_opacity()` (input clamped)

| Backend | Implementation |
| --- | --- |
| macOS WebView / CEF | `NSWindow.alphaValue` |
| Windows WebView2 / CEF | layered window + `SetLayeredWindowAttributes(LWA_ALPHA)` |
| Linux WebView | `gtk_widget_set_opacity` |
| Linux CEF | `_NET_WM_WINDOW_OPACITY` X11 hint |
| Winit | no opacity API → NULL pointers (no-op, `get` returns 1.0) |

## Transparent background
A creation flag (`LAUFEY_WINDOW_FLAG_TRANSPARENT` / `WindowOptions::transparent`) giving the window a transparent background so the page's own per-pixel alpha composites against whatever is behind the window. Commonly paired with `frameless`.

- macOS WebView: non-opaque window + clear background + `drawsBackground = NO`
- Linux WebView (WebKitGTK): RGBA visual + transparent web-view background
- Winit: `with_transparent(true)`
- Windows WebView2 and CEF paint an opaque window background and ignore the flag (documented)

## Also in this PR
Brings the hand-rolled `backend-winit-common` vtable mirror back in sync: it was pinned at API v26 and missing the v27 `set_page_load_handler` slot, which would mis-align every field after it when the (v27+) capi reads the backend's table. Added that field plus the new opacity slots and bumped the winit backend to v28.

## Testing
- `cargo build --workspace` + `cargo test -p laufey` pass (added flag-mapping test cases)
- macOS WebView backend builds clean (`make webview`)
- macOS CEF backend builds clean (`ninja -C cef/build`)
- `cargo fmt`, `clang-format`, `deno fmt`, `cargo clippy` all clean

The Windows and Linux backend sources can't be compiled in a macOS dev environment, but they mirror the existing `set_always_on_top` / `set_resizable` patterns.