### PR TITLE
fix: honor app icon and app_id on Linux backends

### DIFF
--- a/cef/src/app.cc
+++ b/cef/src/app.cc
@@ -30,6 +30,7 @@ NativeDialogResult ShowNativeJSDialog_Mac(int type, const std::string& message,
 #include "include/wrapper/cef_helpers.h"
 
 std::string g_runtime_path;
+std::string g_app_id;
 std::queue<uint32_t> g_pending_laufey_ids;
 
 namespace {
@@ -84,6 +85,21 @@ cef_state_t LaufeyWindowDelegate::AcceptsFirstMouse(
   return (flags_ & LAUFEY_WINDOW_FLAG_NO_ACTIVATE) ? STATE_ENABLED
                                                    : STATE_DEFAULT;
 }
+
+#if defined(__linux__)
+bool LaufeyWindowDelegate::GetLinuxWindowProperties(
+    CefRefPtr<CefWindow> window, CefLinuxWindowProperties& properties) {
+  if (g_app_id.empty()) {
+    return false;
+  }
+  // Same id for Wayland's app_id and X11's WM_CLASS (both class and name) so
+  // the window matches the installed `<g_app_id>.desktop` under either backend.
+  CefString(&properties.wayland_app_id) = g_app_id;
+  CefString(&properties.wm_class_class) = g_app_id;
+  CefString(&properties.wm_class_name) = g_app_id;
+  return true;
+}
+#endif
 
 void LaufeyWindowDelegate::OnWindowDestroyed(CefRefPtr<CefWindow> window) {
   // Unregister native window

--- a/cef/src/app.h
+++ b/cef/src/app.h
@@ -16,6 +16,14 @@
 
 extern std::string g_runtime_path;
 
+// Wayland app_id / X11 WM_CLASS for the app's windows. Read at startup from
+// LAUFEY_APP_ID (falling back to LAUFEY_APP_NAME). Empty leaves the
+// CEF/Chromium default (the backend binary name). On Wayland the compositor
+// keys the taskbar/overview icon off this app_id matching an installed
+// `<app_id>.desktop`, so it must equal the desktop file's id for the icon to
+// show.
+extern std::string g_app_id;
+
 // Open `url` in the user's default OS browser. Implemented per platform in
 // main_mac.mm / main_windows.cc / main_linux.cc. Used to honor the external
 // link redirect policy (laufey_external_links.h).
@@ -44,6 +52,15 @@ class LaufeyWindowDelegate : public CefWindowDelegate {
   // click without the app having to activate first, so a tray popover can be
   // interacted with while the previously-focused app keeps focus.
   cef_state_t AcceptsFirstMouse(CefRefPtr<CefWindow> window) override;
+
+#if defined(__linux__)
+  // Advertise the Wayland app_id / X11 WM_CLASS (from g_app_id) so window
+  // managers can attribute the right `.desktop` file — and therefore the right
+  // taskbar/overview icon — to our windows. Without this the app_id defaults to
+  // the backend binary name and Wayland shows a generic placeholder icon.
+  bool GetLinuxWindowProperties(CefRefPtr<CefWindow> window,
+                                CefLinuxWindowProperties& properties) override;
+#endif
 
  private:
   CefRefPtr<CefBrowserView> browser_view_;

--- a/cef/src/main_linux.cc
+++ b/cef/src/main_linux.cc
@@ -727,6 +727,22 @@ int main(int argc, char* argv[]) {
     g_runtime_path = LaufeyFindColocatedRuntime();
   }
 
+  // Wayland app_id / X11 WM_CLASS for our windows (see LaufeyWindowDelegate::
+  // GetLinuxWindowProperties). Prefer the reverse-DNS identifier the embedder
+  // also uses for the `.desktop` file; fall back to the display name.
+  if (const char* app_id = getenv("LAUFEY_APP_ID")) {
+    if (*app_id) {
+      g_app_id = app_id;
+    }
+  }
+  if (g_app_id.empty()) {
+    if (const char* app_name = getenv("LAUFEY_APP_NAME")) {
+      if (*app_name) {
+        g_app_id = app_name;
+      }
+    }
+  }
+
   // Check for headless / forked worker mode (skip CEF entirely)
   if (is_forked_worker() || is_cli_worker_command(argc, argv)) {
     return run_headless(g_runtime_path);

--- a/webview/src/main_linux.cc
+++ b/webview/src/main_linux.cc
@@ -14,6 +14,47 @@
 int main(int argc, char* argv[]) {
   gtk_init(&argc, &argv);
 
+  // Application identity for the window manager. The embedder (e.g. deno
+  // desktop) passes LAUFEY_APP_ID (the reverse-DNS identifier it also uses for
+  // the `.desktop` file) and LAUFEY_APP_NAME (the display name). GTK derives a
+  // Wayland xdg_toplevel app_id from g_get_prgname() and an X11 WM_CLASS from
+  // the program class, so set both to the app id — otherwise they default to
+  // this backend binary's name and the compositor shows a generic placeholder
+  // icon instead of the one from the matching `<app_id>.desktop`.
+  std::string appId;
+  if (const char* env = getenv("LAUFEY_APP_ID")) {
+    if (*env) {
+      appId = env;
+    }
+  }
+  if (appId.empty()) {
+    if (const char* env = getenv("LAUFEY_APP_NAME")) {
+      if (*env) {
+        appId = env;
+      }
+    }
+  }
+  if (!appId.empty()) {
+    g_set_prgname(appId.c_str());
+    gdk_set_program_class(appId.c_str());
+  }
+
+  // Default icon for all windows. Wayland ignores client-set window icons (it
+  // relies on the app_id → `.desktop` match above), but X11 honors this, so a
+  // dev run under X11 shows the configured icon directly.
+  if (const char* iconPath = getenv("LAUFEY_APP_ICON")) {
+    if (*iconPath) {
+      GError* error = nullptr;
+      if (!gtk_window_set_default_icon_from_file(iconPath, &error)) {
+        if (error) {
+          std::cerr << "Failed to load app icon '" << iconPath
+                    << "': " << error->message << std::endl;
+          g_error_free(error);
+        }
+      }
+    }
+  }
+
   std::string runtimePath;
   for (int i = 1; i < argc; ++i) {
     if (strcmp(argv[i], "--runtime") == 0 && i + 1 < argc) {


### PR DESCRIPTION
## What

Make the **Linux** CEF and webview backends honor the app-identity environment
variables the embedder already passes (`LAUFEY_APP_ID`, `LAUFEY_APP_NAME`,
`LAUFEY_APP_ICON`) — today only the macOS backends read them.

## Why

On Wayland a compositor resolves a window's icon by matching the window's
`app_id` against an installed `<app_id>.desktop` file. The Linux backends never
set an `app_id`/`WM_CLASS` (it defaulted to the backend binary name) and never
set a window icon, so the icon configured by the embedder was ignored and
GNOME drew its generic placeholder. See denoland/deno#35500.

## Changes

- **CEF** (`app.{h,cc}`, `main_linux.cc`): read `LAUFEY_APP_ID` (falling back to
  `LAUFEY_APP_NAME`) at startup into `g_app_id`, and implement
  `CefWindowDelegate::GetLinuxWindowProperties` to advertise it as
  `wayland_app_id` + `wm_class_class` + `wm_class_name`.
- **webview/GTK** (`main_linux.cc`): set `g_set_prgname()` +
  `gdk_set_program_class()` from the same id (Wayland `app_id` + X11 `WM_CLASS`),
  and set the default window icon from `LAUFEY_APP_ICON` via
  `gtk_window_set_default_icon_from_file()`.

Both backends end up presenting an identical identity (`app_id` / `WM_CLASS`
both equal to the reverse-DNS id), which is what an embedder's generated
`.desktop` `StartupWMClass` keys off of.

## Companion change

deno's `deno desktop` is updated to pass `LAUFEY_APP_ID` (the same reverse-DNS
id it uses for the `.desktop` filename / `StartupWMClass`) in both the packaged
launcher and the dev run: denoland/deno PR (linked below).

## Notes / testing

- macOS and Windows are unaffected (the new code is `#if defined(__linux__)`).
- Direct window icons can't be set on Wayland by design (GTK3/Chromium have no
  client API); packaged apps work via the `app_id` → `.desktop` match, and X11
  also shows the icon directly through the GTK default icon. A bare dev run on
  Wayland still has no installed `.desktop` to resolve against.
- The Linux `.cc` changes were authored/reviewed on a macOS host and should get
  a build + run on a Linux + Wayland box before merge.
