### PR TITLE
fix(cef): register custom schemes in sub-processes so app:// pages load

### DIFF
--- a/cef/src/app.cc
+++ b/cef/src/app.cc
@@ -442,10 +442,7 @@ bool LaufeyHandler::OnProcessMessageReceived(
 
 void LaufeyApp::OnRegisterCustomSchemes(
     CefRawPtr<CefSchemeRegistrar> registrar) {
-  registrar->AddCustomScheme(
-      LAUFEY_APP_SCHEME, CEF_SCHEME_OPTION_STANDARD | CEF_SCHEME_OPTION_SECURE |
-                             CEF_SCHEME_OPTION_CORS_ENABLED |
-                             CEF_SCHEME_OPTION_FETCH_ENABLED);
+  RegisterLaufeyCustomSchemes(registrar);
 }
 
 void LaufeyApp::OnContextInitialized() {

--- a/cef/src/renderer_app.cc
+++ b/cef/src/renderer_app.cc
@@ -2,15 +2,12 @@
 
 #include "renderer_app.h"
 
-#include "scheme_handler.h"  // LAUFEY_APP_SCHEME
+#include "scheme_handler.h"  // RegisterLaufeyCustomSchemes
 
 LaufeyRendererApp::LaufeyRendererApp()
     : render_handler_(new LaufeyRenderProcessHandler()) {}
 
 void LaufeyRendererApp::OnRegisterCustomSchemes(
     CefRawPtr<CefSchemeRegistrar> registrar) {
-  registrar->AddCustomScheme(
-      LAUFEY_APP_SCHEME, CEF_SCHEME_OPTION_STANDARD | CEF_SCHEME_OPTION_SECURE |
-                             CEF_SCHEME_OPTION_CORS_ENABLED |
-                             CEF_SCHEME_OPTION_FETCH_ENABLED);
+  RegisterLaufeyCustomSchemes(registrar);
 }

--- a/cef/src/renderer_app.cc
+++ b/cef/src/renderer_app.cc
@@ -2,5 +2,15 @@
 
 #include "renderer_app.h"
 
+#include "scheme_handler.h"  // LAUFEY_APP_SCHEME
+
 LaufeyRendererApp::LaufeyRendererApp()
     : render_handler_(new LaufeyRenderProcessHandler()) {}
+
+void LaufeyRendererApp::OnRegisterCustomSchemes(
+    CefRawPtr<CefSchemeRegistrar> registrar) {
+  registrar->AddCustomScheme(
+      LAUFEY_APP_SCHEME, CEF_SCHEME_OPTION_STANDARD | CEF_SCHEME_OPTION_SECURE |
+                             CEF_SCHEME_OPTION_CORS_ENABLED |
+                             CEF_SCHEME_OPTION_FETCH_ENABLED);
+}

--- a/cef/src/renderer_app.h
+++ b/cef/src/renderer_app.h
@@ -4,6 +4,7 @@
 #define LAUFEY_RENDERER_APP_H_
 
 #include "include/cef_app.h"
+#include "include/cef_scheme.h"
 #include "render_process_handler.h"
 
 class LaufeyRendererApp : public CefApp {
@@ -13,6 +14,16 @@ class LaufeyRendererApp : public CefApp {
   CefRefPtr<CefRenderProcessHandler> GetRenderProcessHandler() override {
     return render_handler_;
   }
+
+  // Custom schemes must be registered in EVERY process (browser, renderer,
+  // and the network service), not just the browser. This CefApp is the one
+  // passed to CefExecuteProcess for all sub-processes, so it must mirror
+  // LaufeyApp::OnRegisterCustomSchemes — otherwise the network service does
+  // not know the scheme is standard and rejects navigations to it
+  // (VALIDATION_ERROR_DESERIALIZATION_FAILED on network.mojom.NetworkContext),
+  // leaving the page blank.
+  void OnRegisterCustomSchemes(
+      CefRawPtr<CefSchemeRegistrar> registrar) override;
 
  private:
   CefRefPtr<LaufeyRenderProcessHandler> render_handler_;

--- a/cef/src/renderer_app.h
+++ b/cef/src/renderer_app.h
@@ -15,13 +15,10 @@ class LaufeyRendererApp : public CefApp {
     return render_handler_;
   }
 
-  // Custom schemes must be registered in EVERY process (browser, renderer,
-  // and the network service), not just the browser. This CefApp is the one
-  // passed to CefExecuteProcess for all sub-processes, so it must mirror
-  // LaufeyApp::OnRegisterCustomSchemes — otherwise the network service does
-  // not know the scheme is standard and rejects navigations to it
-  // (VALIDATION_ERROR_DESERIALIZATION_FAILED on network.mojom.NetworkContext),
-  // leaving the page blank.
+  // This CefApp is the one passed to CefExecuteProcess for all sub-processes
+  // (renderer, GPU, network service), which must declare custom standard
+  // schemes just like the browser process; see RegisterLaufeyCustomSchemes in
+  // scheme_handler.h.
   void OnRegisterCustomSchemes(
       CefRawPtr<CefSchemeRegistrar> registrar) override;
 

--- a/cef/src/scheme_handler.h
+++ b/cef/src/scheme_handler.h
@@ -14,9 +14,24 @@
 
 // The custom standard scheme laufey registers for in-process app serving
 // (e.g. "app://..."). Declared as a standard, secure, fetch/CORS-enabled
-// scheme in LaufeyApp::OnRegisterCustomSchemes so pages served over it behave
-// like normal https origins.
+// scheme so pages served over it behave like normal https origins.
 #define LAUFEY_APP_SCHEME "app"
+
+// Registers LAUFEY_APP_SCHEME with the given registrar. A custom standard
+// scheme must be declared identically in EVERY process — the browser
+// (LaufeyApp) and all sub-processes including the network service
+// (LaufeyRendererApp, handed to CefExecuteProcess) — otherwise the network
+// service does not know the scheme is standard and rejects navigations to it
+// (VALIDATION_ERROR_DESERIALIZATION_FAILED on network.mojom.NetworkContext),
+// leaving the page blank. Both OnRegisterCustomSchemes overrides call this
+// single definition so the flags cannot drift apart.
+inline void RegisterLaufeyCustomSchemes(
+    CefRawPtr<CefSchemeRegistrar> registrar) {
+  registrar->AddCustomScheme(
+      LAUFEY_APP_SCHEME, CEF_SCHEME_OPTION_STANDARD | CEF_SCHEME_OPTION_SECURE |
+                             CEF_SCHEME_OPTION_CORS_ENABLED |
+                             CEF_SCHEME_OPTION_FETCH_ENABLED);
+}
 
 // A CefResourceHandler that bridges a single webview request to the laufey
 // runtime's registered scheme handler. The handler object IS the opaque

--- a/examples/cef_e2e/src/lib.rs
+++ b/examples/cef_e2e/src/lib.rs
@@ -177,6 +177,51 @@ async function waitForBinding(name) {
             binding_calls.load(Ordering::SeqCst) >= 2,
         );
 
+        // Custom-scheme (app://) navigation. A custom standard scheme only
+        // works if it is registered in EVERY process — browser, renderer, AND
+        // the network service. If LaufeyRendererApp (the CefApp for all
+        // sub-processes) does not mirror LaufeyApp::OnRegisterCustomSchemes,
+        // the network service rejects the navigation with
+        // VALIDATION_ERROR_DESERIALIZATION_FAILED on network.mojom.NetworkContext
+        // and the page stays blank. Serve a tiny page over app:// and confirm
+        // its script round-trips back through the `report` binding.
+        let app_html: &[u8] = br#"<!doctype html><html><body><script>
+(async () => {
+  for (let i = 0; i < 100; i++) {
+    if (typeof Laufey === 'object' && typeof Laufey.report === 'function') break;
+    await new Promise(r => setTimeout(r, 50));
+  }
+  try { await Laufey.report('app-scheme-loaded'); } catch (_) {}
+})();
+</script></body></html>"#;
+        let sh_handle = tokio::runtime::Handle::current();
+        laufey::register_scheme_handler("app", move |req| {
+            // The handler runs on a backend IO thread and must not block it,
+            // so serve the response from a spawned task.
+            sh_handle.spawn(async move {
+                let ex = req.exchange;
+                ex.begin(
+                    200,
+                    &[("content-type".to_string(), "text/html".to_string())],
+                );
+                ex.write(app_html);
+                ex.finish();
+            });
+        });
+        win.navigate("app://e2e/");
+        let saw_app_scheme = wait_for(
+            || {
+                last_label.lock().unwrap().as_deref() == Some("app-scheme-loaded")
+            },
+            200,
+            50,
+        )
+        .await;
+        check(
+            "custom app:// scheme navigation loaded (all-process scheme registration)",
+            saw_app_scheme,
+        );
+
         // executeJs round-trip. The capi has an `execute_js` API with
         // optional callback that delivers the JS expression's result
         // back to Rust.


### PR DESCRIPTION
## Problem
On the CEF backend, navigating a window to a custom standard scheme served via
`register_scheme_handler` (e.g. `app://`, which the Deno desktop runtime uses
for in-process app serving) leaves the window blank. The scheme handler runs
and produces a response, but the navigation never commits, and stderr floods
with:

```
Invalid message: VALIDATION_ERROR_DESERIALIZATION_FAILED
Message … rejected by interface network.mojom.NetworkContext
Message … rejected by interface content.mojom.NavigationClient
```

Built-in schemes (`data:`, `https:`) are unaffected — only custom schemes fail.

## Root cause
`OnRegisterCustomSchemes` was implemented only on `LaufeyApp` (the browser
process). The CefApp handed to `CefExecuteProcess` for **every sub-process**
(`helper.cc` → `LaufeyRendererApp`) did not override it. A custom **standard**
scheme must be registered in every process — including the **network service**
utility process — or the network service rejects navigations to it. This is the
same issue Electron fixed in electron/electron#22867 ("ensure standard schemes
are registered in nw service process").

## Fix
Add `OnRegisterCustomSchemes` to `LaufeyRendererApp`, mirroring `LaufeyApp`, so
`LAUFEY_APP_SCHEME` is declared in the renderer, GPU, and network-service
processes too.

## Verification
Added an `app://` case to the `cef_e2e` harness (it previously only exercised a
`data:` URL, which can't hit this bug). It serves a page over a registered
`app://` handler and checks the page's script round-trips back through a binding.

| | `network.mojom.NetworkContext` errors | `app://` result |
|---|---|---|
| before | 868 | ❌ page never loads → e2e OVERALL FAIL |
| after  | 0   | ✅ page loads → e2e OVERALL PASS |