### PR TITLE
fix(cef): don't let the page title overwrite an app-set window title

### DIFF
--- a/cef/src/app.cc
+++ b/cef/src/app.cc
@@ -206,6 +206,14 @@ void LaufeyHandler::OnBeforeClose(CefRefPtr<CefBrowser> browser) {
 void LaufeyHandler::OnTitleChange(CefRefPtr<CefBrowser> browser,
                                   const CefString& title) {
   CEF_REQUIRE_UI_THREAD();
+  // Don't let the page's document.title (or the URL, which CEF falls back to
+  // when the document has no <title>) clobber a title the embedder set
+  // explicitly via the C API.
+  auto* loader = RuntimeLoader::GetInstance();
+  uint32_t wid = loader ? loader->GetLaufeyIdForBrowser(browser) : 0;
+  if (wid > 0 && loader->HasExplicitTitle(wid)) {
+    return;
+  }
   if (auto browser_view = CefBrowserView::GetForBrowser(browser)) {
     if (auto window = browser_view->GetWindow()) {
       window->SetTitle(title);

--- a/cef/src/runtime_loader.cc
+++ b/cef/src/runtime_loader.cc
@@ -165,6 +165,9 @@ static void Backend_Navigate(void* data, uint32_t window_id, const char* url) {
 static void Backend_SetTitle(void* data, uint32_t window_id,
                              const char* title) {
   RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);
+  // The embedder set an explicit title; keep the page's document.title / URL
+  // from overwriting it later (see LaufeyHandler::OnTitleChange).
+  loader->MarkExplicitTitle(window_id);
   CefRefPtr<CefBrowser> browser = loader->GetBrowserForWindow(window_id);
   if (browser && title) {
     std::string title_str(title);

--- a/cef/src/runtime_loader.h
+++ b/cef/src/runtime_loader.h
@@ -10,6 +10,7 @@
 #include <condition_variable>
 #include <queue>
 #include <map>
+#include <set>
 
 #include "include/cef_browser.h"
 #include "include/cef_values.h"
@@ -102,6 +103,19 @@ class RuntimeLoader {
       return wid;
     }
     return 0;
+  }
+
+  // Records that the embedder explicitly set this window's title via the C
+  // API. Once set, the page's document.title / URL must not clobber it (see
+  // LaufeyHandler::OnTitleChange).
+  void MarkExplicitTitle(uint32_t window_id) {
+    std::lock_guard<std::mutex> lock(windows_mutex_);
+    explicit_title_windows_.insert(window_id);
+  }
+
+  bool HasExplicitTitle(uint32_t window_id) {
+    std::lock_guard<std::mutex> lock(windows_mutex_);
+    return explicit_title_windows_.count(window_id) > 0;
   }
 
   void RegisterNSWindow(void* nswindow, uint32_t window_id) {
@@ -358,6 +372,9 @@ class RuntimeLoader {
       call_to_window_;  // call_id -> window_id for JsCallRespond
   std::map<void*, uint32_t> nswindow_to_laufey_id_;
   std::map<void*, uint32_t> native_handle_to_laufey_id_;
+  // Windows whose title was explicitly set by the embedder; their titles are
+  // not overwritten by the page's document.title / URL.
+  std::set<uint32_t> explicit_title_windows_;
   std::mutex windows_mutex_;
   std::condition_variable browser_ready_cv_;
   std::atomic<uint32_t> next_window_id_{1};


### PR DESCRIPTION
## Problem

A CEF window whose title is set via the C API (`set_title` / `BrowserWindow.setTitle`) ends up showing the **page URL** instead of the app-set title.

## Cause

`LaufeyHandler::OnTitleChange` unconditionally calls `window->SetTitle(page_title)`. When the loaded document has no `<title>`, CEF supplies the URL, which clobbers the title the embedder set.

## Fix

- `RuntimeLoader` tracks an `explicit_title_windows_` set; `Backend_SetTitle` marks the window.
- `OnTitleChange` returns early for marked windows, so an app-set title sticks.
- Windows that never call `set_title` still mirror the page title as before.

Found while testing `deno desktop` (CEF backend) window features on Windows.