### PR TITLE
fix(webview/macos): implement runOpenPanel so `<input type="file">` works

### DIFF
--- a/webview/src/webview_macos.mm
+++ b/webview/src/webview_macos.mm
@@ -435,14 +435,14 @@ class MacSchemeExchange : public SchemeExchangeBase {
   }
 }
 
-// `<input type="file">`. WKWebView has no default handler; the host must present
-// the open panel or the input stays inert. Honor multiple-selection and
+// `<input type="file">`. WKWebView has no default handler; the host must
+// present the open panel or the input stays inert. Honor multiple-selection and
 // directory flags from the parameters, and attach as a sheet to the window.
 - (void)webView:(WKWebView*)webView
     runOpenPanelWithParameters:(WKOpenPanelParameters*)parameters
               initiatedByFrame:(WKFrameInfo*)frame
-             completionHandler:(void (^)(NSArray<NSURL*>* _Nullable))
-                                   completionHandler {
+             completionHandler:
+                 (void (^)(NSArray<NSURL*>* _Nullable))completionHandler {
   NSOpenPanel* panel = [NSOpenPanel openPanel];
   [panel setAllowsMultipleSelection:parameters.allowsMultipleSelection];
   [panel setCanChooseDirectories:parameters.allowsDirectories];

--- a/webview/src/webview_macos.mm
+++ b/webview/src/webview_macos.mm
@@ -435,6 +435,35 @@ class MacSchemeExchange : public SchemeExchangeBase {
   }
 }
 
+// `<input type="file">`. WKWebView has no default handler; the host must present
+// the open panel or the input stays inert. Honor multiple-selection and
+// directory flags from the parameters, and attach as a sheet to the window.
+- (void)webView:(WKWebView*)webView
+    runOpenPanelWithParameters:(WKOpenPanelParameters*)parameters
+              initiatedByFrame:(WKFrameInfo*)frame
+             completionHandler:(void (^)(NSArray<NSURL*>* _Nullable))
+                                   completionHandler {
+  NSOpenPanel* panel = [NSOpenPanel openPanel];
+  [panel setAllowsMultipleSelection:parameters.allowsMultipleSelection];
+  [panel setCanChooseDirectories:parameters.allowsDirectories];
+  [panel setCanChooseFiles:!parameters.allowsDirectories];
+
+  void (^handler)(NSModalResponse) = ^(NSModalResponse response) {
+    if (response == NSModalResponseOK) {
+      completionHandler([panel URLs]);
+    } else {
+      completionHandler(nil);
+    }
+  };
+
+  NSWindow* window = webView.window;
+  if (window) {
+    [panel beginSheetModalForWindow:window completionHandler:handler];
+  } else {
+    handler([panel runModal]);
+  }
+}
+
 @end
 
 @interface LaufeyWindowDelegate : NSObject <NSWindowDelegate>


### PR DESCRIPTION
Fixes #36.

## Problem
macOS WKWebView is the one engine that requires the host's `WKUIDelegate` to implement `webView:runOpenPanelWithParameters:initiatedByFrame:completionHandler:`. `LaufeyUIDelegate` implemented the alert/confirm/prompt panels but not this one, so the completion handler never ran and clicking any `<input type="file">` was silently inert. Every other backend gets an engine default (WebKitGTK `run-file-chooser`, WebView2 native, CEF `OnFileDialog`, iOS WKWebView).

## Fix
Add `runOpenPanelWithParameters:` to `LaufeyUIDelegate`:
- Presents an `NSOpenPanel`.
- Honors `parameters.allowsMultipleSelection` and `parameters.allowsDirectories` (and sets `canChooseFiles` inversely).
- Attaches as a sheet via `beginSheetModalForWindow:` when the webview has a window; falls back to `runModal` otherwise.
- OK → `completionHandler(panel.URLs)`, cancel → `completionHandler(nil)`.

~29 lines, same shape as the existing prompt-panel handler.

## Testing
Built the webview backend and ran it against a page with `<input type="file">`. The native open panel now appears and, after selecting a file, the page's `change` handler fires with the chosen filename (`picked: <name>`) — proving the completion handler delivers the URLs back to WebKit. Before this change the click produced no panel and no event.

## Out of scope
The issue's "related gap" (a JS-invokable `choose_file`/`choose_folder` vtable entry for programmatic path selection) is a separate feature and not addressed here.