### PR TITLE
fix(cef): silence Chromium's internal ERROR log noise

### DIFF
--- a/cef/src/app.h
+++ b/cef/src/app.h
@@ -3,6 +3,8 @@
 #ifndef LAUFEY_APP_H_
 #define LAUFEY_APP_H_
 
+#include <cctype>
+#include <cstdlib>
 #include <list>
 #include <map>
 #include <queue>
@@ -15,6 +17,39 @@
 #include "include/views/cef_window.h"
 
 extern std::string g_runtime_path;
+
+// Default CEF log severity for CefSettings.log_severity.
+//
+// Chromium continuously logs ERROR/WARNING lines that are irrelevant to an
+// embedded webview app and not actionable by the app developer: GCM
+// registration failures (`registration_request.cc ... PHONE_REGISTRATION_ERROR`
+// / `DEPRECATED_ENDPOINT`), on-device model service disconnects
+// (`on_device_model/...`), xdg desktop-portal "Request cancelled by user",
+// long-running `CompositorAnimationObserver` warnings, "Unable to get gpu
+// adapter", etc. Targeted `--disable-*` switches can't cover all of them (the
+// portal and compositor messages aren't feature-gated), so raise the log floor
+// to FATAL by default to hide the noise — matching what Electron production
+// apps do. Set LAUFEY_CEF_LOG_SEVERITY to restore output while debugging:
+// verbose | debug | info | warning | error | fatal | disable | default.
+inline cef_log_severity_t LaufeyCefLogSeverity() {
+  const char* env = getenv("LAUFEY_CEF_LOG_SEVERITY");
+  if (!env || !*env) {
+    return LOGSEVERITY_FATAL;
+  }
+  std::string v(env);
+  for (char& c : v) {
+    c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+  }
+  if (v == "verbose") return LOGSEVERITY_VERBOSE;
+  if (v == "debug") return LOGSEVERITY_DEBUG;
+  if (v == "info") return LOGSEVERITY_INFO;
+  if (v == "warning") return LOGSEVERITY_WARNING;
+  if (v == "error") return LOGSEVERITY_ERROR;
+  if (v == "fatal") return LOGSEVERITY_FATAL;
+  if (v == "disable") return LOGSEVERITY_DISABLE;
+  if (v == "default") return LOGSEVERITY_DEFAULT;
+  return LOGSEVERITY_FATAL;
+}
 
 // Wayland app_id / X11 WM_CLASS for the app's windows. Read at startup from
 // LAUFEY_APP_ID (falling back to LAUFEY_APP_NAME). Empty leaves the

--- a/cef/src/app.h
+++ b/cef/src/app.h
@@ -40,14 +40,22 @@ inline cef_log_severity_t LaufeyCefLogSeverity() {
   for (char& c : v) {
     c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
   }
-  if (v == "verbose") return LOGSEVERITY_VERBOSE;
-  if (v == "debug") return LOGSEVERITY_DEBUG;
-  if (v == "info") return LOGSEVERITY_INFO;
-  if (v == "warning") return LOGSEVERITY_WARNING;
-  if (v == "error") return LOGSEVERITY_ERROR;
-  if (v == "fatal") return LOGSEVERITY_FATAL;
-  if (v == "disable") return LOGSEVERITY_DISABLE;
-  if (v == "default") return LOGSEVERITY_DEFAULT;
+  if (v == "verbose")
+    return LOGSEVERITY_VERBOSE;
+  if (v == "debug")
+    return LOGSEVERITY_DEBUG;
+  if (v == "info")
+    return LOGSEVERITY_INFO;
+  if (v == "warning")
+    return LOGSEVERITY_WARNING;
+  if (v == "error")
+    return LOGSEVERITY_ERROR;
+  if (v == "fatal")
+    return LOGSEVERITY_FATAL;
+  if (v == "disable")
+    return LOGSEVERITY_DISABLE;
+  if (v == "default")
+    return LOGSEVERITY_DEFAULT;
   return LOGSEVERITY_FATAL;
 }
 

--- a/cef/src/main_linux.cc
+++ b/cef/src/main_linux.cc
@@ -801,6 +801,7 @@ int main(int argc, char* argv[]) {
 
   CefSettings settings;
   settings.no_sandbox = true;
+  settings.log_severity = LaufeyCefLogSeverity();
 
   // Set cache path
   std::string cache_path = "/tmp/laufey_cef_" + std::to_string(getpid());

--- a/cef/src/main_mac.mm
+++ b/cef/src/main_mac.mm
@@ -354,6 +354,7 @@ int main(int argc, char* argv[]) {
 
     CefSettings settings;
     settings.no_sandbox = true;
+    settings.log_severity = LaufeyCefLogSeverity();
     // Run [NSApp run] as the message loop (see LaufeyPumpTarget) so the main
     // libdispatch queue is serviced — required for tray/status items.
     settings.external_message_pump = true;

--- a/cef/src/main_windows.cc
+++ b/cef/src/main_windows.cc
@@ -285,6 +285,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
 
   CefSettings settings;
   settings.no_sandbox = true;
+  settings.log_severity = LaufeyCefLogSeverity();
 
   // Set cache path
   char tempPath[MAX_PATH];

--- a/webview/src/webview_ios.mm
+++ b/webview/src/webview_ios.mm
@@ -115,7 +115,8 @@ class WKWebViewIOSBackend : public LaufeyBackend {
   int ShowDialog(uint32_t, int dialog_type, const std::string& title,
                  const std::string& message, const std::string&,
                  char** out_input_value) override {
-    if (out_input_value) *out_input_value = nullptr;
+    if (out_input_value)
+      *out_input_value = nullptr;
     NSString* t = [NSString stringWithUTF8String:title.c_str()];
     NSString* m = [NSString stringWithUTF8String:message.c_str()];
     __block int result = 0;
@@ -133,23 +134,30 @@ class WKWebViewIOSBackend : public LaufeyBackend {
                                              style:UIAlertActionStyleDefault
                                            handler:^(UIAlertAction*) {
                                              result = 1;
-                                             if (sem) dispatch_semaphore_signal(sem);
+                                             if (sem)
+                                               dispatch_semaphore_signal(sem);
                                            }]];
       if (dialog_type != LAUFEY_DIALOG_ALERT) {
         [ac addAction:[UIAlertAction actionWithTitle:@"Cancel"
                                                style:UIAlertActionStyleCancel
                                              handler:^(UIAlertAction*) {
                                                result = 0;
-                                               if (sem) dispatch_semaphore_signal(sem);
+                                               if (sem)
+                                                 dispatch_semaphore_signal(sem);
                                              }]];
       }
       UIWindow* key = nil;
       for (UIWindow* w in UIApplication.sharedApplication.windows) {
-        if (w.isKeyWindow) { key = w; break; }
+        if (w.isKeyWindow) {
+          key = w;
+          break;
+        }
       }
-      if (!key) key = UIApplication.sharedApplication.windows.firstObject;
+      if (!key)
+        key = UIApplication.sharedApplication.windows.firstObject;
       UIViewController* vc = key.rootViewController;
-      while (vc.presentedViewController) vc = vc.presentedViewController;
+      while (vc.presentedViewController)
+        vc = vc.presentedViewController;
       [vc presentViewController:ac animated:YES completion:nil];
     };
 
@@ -158,7 +166,9 @@ class WKWebViewIOSBackend : public LaufeyBackend {
       return 1;
     }
     dispatch_semaphore_t sem = dispatch_semaphore_create(0);
-    dispatch_async(dispatch_get_main_queue(), ^{ present(sem); });
+    dispatch_async(dispatch_get_main_queue(), ^{
+      present(sem);
+    });
     dispatch_semaphore_wait(sem, DISPATCH_TIME_FOREVER);
     return result;
   }


### PR DESCRIPTION
## Problem

Addresses denoland/deno#35781. Even with `--disable-background-networking` (added in #25), CEF apps still emit a stream of Chromium-internal `ERROR` lines at startup that are irrelevant to an embedded webview app and not actionable by the app developer:

```
ERROR:google_apis/gcm/engine/registration_request.cc:291] Registration response error message: PHONE_REGISTRATION_ERROR
ERROR:google_apis/gcm/engine/registration_request.cc:291] Registration response error message: DEPRECATED_ENDPOINT
ERROR:components/dbus/xdg/request.cc:161] Request cancelled by user.
ERROR:services/on_device_model/ml/gpu_blocklist.cc:118] Unable to get gpu adapter
ERROR:services/on_device_model/public/cpp/service_client.cc:36] Unexpected on_device_model service disconnect
ERROR:ui/compositor/compositor_animation_observer.cc:65] CompositorAnimationObserver is active for too long
```

## Approach

Targeted `--disable-*` switches (the #25 approach) can't cover all of these — the xdg desktop-portal and `CompositorAnimationObserver` messages aren't feature-gated, so no switch silences them. The reliable catch-all is CEF's `CefSettings.log_severity`.

This raises the log floor to `LOGSEVERITY_FATAL` by default, hiding the noise — matching what Electron production apps do. A new `LAUFEY_CEF_LOG_SEVERITY` env var (`verbose|debug|info|warning|error|fatal|disable|default`) restores output for debugging. The existing `--disable-background-networking` switches are kept; this layers on top.

## Changes

- `cef/src/app.h` — shared inline `LaufeyCefLogSeverity()` helper (all three platforms already include `app.h`).
- `cef/src/main_linux.cc`, `main_windows.cc`, `main_mac.mm` — set `settings.log_severity = LaufeyCefLogSeverity();`.

## Testing

Not runtime-verified locally — the CEF SDK isn't vendored in the checkout, so I couldn't build/run. The `LOGSEVERITY_*` enum names and `CefSettings.log_severity` field are standard CEF API and will compile against the real headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)