### PR TITLE
fix(webview/macos): stop over-releasing windows on close under ARC

### DIFF
--- a/webview/src/webview_ios.mm
+++ b/webview/src/webview_ios.mm
@@ -115,7 +115,8 @@ class WKWebViewIOSBackend : public LaufeyBackend {
   int ShowDialog(uint32_t, int dialog_type, const std::string& title,
                  const std::string& message, const std::string&,
                  char** out_input_value) override {
-    if (out_input_value) *out_input_value = nullptr;
+    if (out_input_value)
+      *out_input_value = nullptr;
     NSString* t = [NSString stringWithUTF8String:title.c_str()];
     NSString* m = [NSString stringWithUTF8String:message.c_str()];
     __block int result = 0;
@@ -133,23 +134,30 @@ class WKWebViewIOSBackend : public LaufeyBackend {
                                              style:UIAlertActionStyleDefault
                                            handler:^(UIAlertAction*) {
                                              result = 1;
-                                             if (sem) dispatch_semaphore_signal(sem);
+                                             if (sem)
+                                               dispatch_semaphore_signal(sem);
                                            }]];
       if (dialog_type != LAUFEY_DIALOG_ALERT) {
         [ac addAction:[UIAlertAction actionWithTitle:@"Cancel"
                                                style:UIAlertActionStyleCancel
                                              handler:^(UIAlertAction*) {
                                                result = 0;
-                                               if (sem) dispatch_semaphore_signal(sem);
+                                               if (sem)
+                                                 dispatch_semaphore_signal(sem);
                                              }]];
       }
       UIWindow* key = nil;
       for (UIWindow* w in UIApplication.sharedApplication.windows) {
-        if (w.isKeyWindow) { key = w; break; }
+        if (w.isKeyWindow) {
+          key = w;
+          break;
+        }
       }
-      if (!key) key = UIApplication.sharedApplication.windows.firstObject;
+      if (!key)
+        key = UIApplication.sharedApplication.windows.firstObject;
       UIViewController* vc = key.rootViewController;
-      while (vc.presentedViewController) vc = vc.presentedViewController;
+      while (vc.presentedViewController)
+        vc = vc.presentedViewController;
       [vc presentViewController:ac animated:YES completion:nil];
     };
 
@@ -158,7 +166,9 @@ class WKWebViewIOSBackend : public LaufeyBackend {
       return 1;
     }
     dispatch_semaphore_t sem = dispatch_semaphore_create(0);
-    dispatch_async(dispatch_get_main_queue(), ^{ present(sem); });
+    dispatch_async(dispatch_get_main_queue(), ^{
+      present(sem);
+    });
     dispatch_semaphore_wait(sem, DISPATCH_TIME_FOREVER);
     return result;
   }

--- a/webview/src/webview_macos.mm
+++ b/webview/src/webview_macos.mm
@@ -820,6 +820,17 @@ void WKWebViewBackend::CreateWindowEx(uint32_t window_id, int width, int height,
                                                backing:NSBackingStoreBuffered
                                                  defer:NO];
       }
+      // Under ARC this object's lifetime is owned entirely by our strong
+      // references (the windows_ map, the local `win` in CloseWindow, and the
+      // event-monitor / notification blocks that capture it). AppKit's legacy
+      // default is releasedWhenClosed == YES, which makes `[window close]`
+      // perform an *extra* release that ARC never balances. That over-release
+      // deallocates the window while it is still referenced, and the stale
+      // pointer is drained on the next main-thread autorelease-pool cleanup —
+      // an EXC_BAD_ACCESS (freed 0xa1a1a1a1 pattern) seconds after the window
+      // closes. Opt out so ARC is the sole owner of the window's lifetime.
+      [window setReleasedWhenClosed:NO];
+
       [window center];
 
       LaufeyWindowDelegate* delegate = [[LaufeyWindowDelegate alloc] init];


### PR DESCRIPTION
## Problem

Native SIGSEGV use-after-free on macOS arm64, `EXC_BAD_ACCESS` with the freed `0xa1a1a1a1` pattern in x22, seconds after closing a `BrowserWindow` while a tray panel is attached. Crash happens on the main thread during autorelease-pool cleanup, outside JS. Reported as denoland/deno#35840.

## Root cause

`CreateWindowEx` in `webview/src/webview_macos.mm` creates each `NSWindow` / `NSPanel` with AppKit's legacy default `releasedWhenClosed == YES`.

ARC is enabled (`-fobjc-arc`, `webview/CMakeLists.txt`), so the window's lifetime is already owned entirely by our strong references — the `windows_` map, the local `win` in `CloseWindow`, and the event-monitor / notification blocks that capture the window. When `CloseWindow` calls `[win close]`, AppKit performs an **extra** internal `release` because `releasedWhenClosed` is `YES`. ARC never balances it → net over-release by one → the window is deallocated while still referenced → the stale object is drained on the next main-thread autorelease-pool turn → crash a few seconds later.

Combining a non-activating `NSPanel` (the tray-attached popover) with a `BrowserWindow` makes it reproduce reliably: the extra live references guarantee the over-release lands on a still-referenced object.

## Fix

Set `[window setReleasedWhenClosed:NO]` for both the window and panel paths right after creation, so ARC is the sole owner of the lifetime. `[win close]` then just orders the window out; dealloc happens exactly once when the last strong ref is dropped.

Fixes denoland/deno#35840