### PR TITLE
fix(webview/macos): pin deployment target so bundles run on older macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,6 +246,12 @@ jobs:
   build-webview:
     name: webview / ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
+    # Keep the macOS minimum in sync with LSMinimumSystemVersion in
+    # webview/macos/Info.plist.in (denoland/deno#35764). Ignored on non-macOS
+    # runners. The webview CMakeLists also pins this; setting it here guards
+    # against SDK-default minos stamping regardless of build path.
+    env:
+      MACOSX_DEPLOYMENT_TARGET: "10.15"
     strategy:
       fail-fast: false
       matrix:

--- a/webview/CMakeLists.txt
+++ b/webview/CMakeLists.txt
@@ -14,6 +14,21 @@ elseif(WIN32)
   set(PLATFORM_WINDOWS TRUE)
 endif()
 
+# Pin the macOS deployment target so the binary's LC_BUILD_VERSION minos matches
+# the LSMinimumSystemVersion declared in macos/Info.plist.in. Without this the
+# compiler stamps the build machine's SDK version (e.g. 14.0) as the minimum,
+# and macOS enforces that Mach-O field at launch — refusing to start on older
+# systems regardless of the Info.plist value (denoland/deno#35764). The CEF
+# backend gets this for free via cef_variables; the webview backend must set it
+# explicitly. Set before add_subdirectory(backend-common) so the shared static
+# lib inherits the same target (see backend-common/CMakeLists.txt).
+# The webview code uses runtime feature detection (respondsToSelector:,
+# valueForKey:/@try) rather than compile-time @available, so a low floor is safe.
+if(PLATFORM_MACOS)
+  set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING
+      "Minimum macOS version" FORCE)
+endif()
+
 # Shared native-API implementations (notifications, tray, dock, dialogs, ...).
 # Each platform branch links laufey_backend_common below. iOS doesn't use it
 # (those are desktop-only AppKit/GTK surfaces); it compiles just the value


### PR DESCRIPTION
## Problem

A bundled `deno desktop` app fails to launch on older macOS (e.g. Monterey 12.7) with **"requires macOS 14.0 or later"**, even though the app's `Info.plist` correctly declares `LSMinimumSystemVersion` = `10.15`.

Reported in denoland/deno#35764.

## Root cause

The `laufey_webview` binary is compiled **without a macOS deployment target**, so its Mach-O `LC_BUILD_VERSION` minos field gets stamped with the *build machine's SDK version* — macOS 14/15 on the CI runners (`macos-14` / `macos-15-intel`). macOS enforces that binary field at launch; the `Info.plist` value is only advisory. So the binary says "14.0" while the plist says "10.15", and the OS refuses to start it on 12.7.

The **CEF** backend doesn't hit this because `include(cef_variables)` sets `CMAKE_OSX_DEPLOYMENT_TARGET` for it. The **webview** backend never set one — and `backend-common/CMakeLists.txt` is written to *inherit* a target from its parent, but the webview parent never provided it, so the inheritance was a no-op.

## Fix

- `webview/CMakeLists.txt`: pin `CMAKE_OSX_DEPLOYMENT_TARGET` to `10.15` (matching the plist) for the macOS build, set **before** `add_subdirectory(backend-common)` so the shared static lib inherits the same target.
- `.github/workflows/ci.yml`: set `MACOSX_DEPLOYMENT_TARGET=10.15` on the `build-webview` job as a pipeline-level guard.

`10.15` matches the value the plist already advertises. The webview code uses runtime feature detection (`respondsToSelector:`, `valueForKey:`/`@try`) rather than compile-time `@available`, so a low deployment floor compiles and runs safely.

## Verification

Not build-verified on macOS (authored on Linux). Before merge, on macOS:

```
make webview
otool -l webview/build/laufey_webview.app/Contents/MacOS/laufey_webview | grep -A4 LC_BUILD_VERSION
```

Expect `minos 10.15`. A quick WKWebView smoke test on an older macOS is ideal.

## Out of scope

The linked issue also reports the main window's close button not working on Sequoia — that's a separate window-management bug and is **not** addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)