### PR TITLE
feat(windows): support aarch64-pc-windows-msvc (Windows on ARM64)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-22.04 }
           - { target: aarch64-unknown-linux-gnu, os: ubuntu-22.04-arm }
           - { target: x86_64-pc-windows-msvc, os: windows-latest }
+          - { target: aarch64-pc-windows-msvc, os: windows-11-arm }
           - { target: x86_64-apple-darwin, os: macos-15-intel }
           - { target: aarch64-apple-darwin, os: macos-14 }
     steps:
@@ -261,6 +262,7 @@ jobs:
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-22.04 }
           - { target: aarch64-unknown-linux-gnu, os: ubuntu-22.04-arm }
           - { target: x86_64-pc-windows-msvc, os: windows-latest }
+          - { target: aarch64-pc-windows-msvc, os: windows-11-arm }
           - { target: x86_64-apple-darwin, os: macos-15-intel }
           - { target: aarch64-apple-darwin, os: macos-14 }
     steps:
@@ -285,6 +287,10 @@ jobs:
 
       - uses: ilammy/msvc-dev-cmd@v1
         if: runner.os == 'Windows'
+        with:
+          # Match the MSVC toolchain to the runner arch so cl.exe targets ARM64
+          # on windows-11-arm; CMake then links the arm64 WebView2 loader.
+          arch: ${{ runner.arch == 'ARM64' && 'arm64' || 'x64' }}
 
       - name: Build
         shell: bash
@@ -381,6 +387,9 @@ jobs:
           - { target: x86_64-apple-darwin, os: macos-15-intel }
           - { target: aarch64-apple-darwin, os: macos-14 }
           - { target: x86_64-pc-windows-msvc, os: windows-latest }
+          # aarch64-pc-windows-msvc (windows-11-arm) is intentionally omitted:
+          # CEF-on-Windows-ARM64 needs the windowsarm64 dist + arch-matched MSVC
+          # setup and is tracked as a separate follow-up (issue #42).
     steps:
       - uses: actions/checkout@v4
 

--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,12 @@ else ifeq ($(HOST_OS),linux)
   endif
   PROJ_ARCH := $(HOST_ARCH)
 else ifeq ($(HOST_OS),windows)
-  CEF_ARCH := windows64
-  PROJ_ARCH := x86_64
+  ifeq ($(HOST_ARCH),aarch64)
+    CEF_ARCH := windowsarm64
+  else
+    CEF_ARCH := windows64
+  endif
+  PROJ_ARCH := $(HOST_ARCH)
 endif
 
 ifeq ($(HOST_OS),windows)

--- a/capi/build.rs
+++ b/capi/build.rs
@@ -20,8 +20,8 @@ fn main() {
     // Pass the real target triple so clang parses with the correct arch on both
     // x64 and ARM64 Windows (aarch64-pc-windows-msvc). Both are LLP64 so the
     // generated layouts match, but hardcoding x86_64 was still wrong.
-    let target_arch =
-      env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_else(|_| "x86_64".to_string());
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH")
+      .unwrap_or_else(|_| "x86_64".to_string());
     let clang_arch = if target_arch == "x86" {
       "i686"
     } else {

--- a/capi/build.rs
+++ b/capi/build.rs
@@ -17,13 +17,23 @@ fn main() {
   // Add compatibility flags to resolve wchar_t typedef redefinition and
   // __declspec attribute errors.
   if cfg!(target_os = "windows") {
+    // Pass the real target triple so clang parses with the correct arch on both
+    // x64 and ARM64 Windows (aarch64-pc-windows-msvc). Both are LLP64 so the
+    // generated layouts match, but hardcoding x86_64 was still wrong.
+    let target_arch =
+      env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_else(|_| "x86_64".to_string());
+    let clang_arch = if target_arch == "x86" {
+      "i686"
+    } else {
+      target_arch.as_str()
+    };
     builder = builder
       .clang_arg("-fms-extensions")
       .clang_arg("-fms-compatibility")
       .clang_arg("-fdelayed-template-parsing")
       .clang_arg("-fmsc-version=1950")
       .clang_arg("-Wno-everything")
-      .clang_arg("--target=x86_64-pc-windows-msvc")
+      .clang_arg(format!("--target={clang_arch}-pc-windows-msvc"))
       .clang_arg("-D_WCHAR_T_DEFINED")
       .clang_arg("-D_NATIVE_WCHAR_T_DEFINED");
   }

--- a/webview/CMakeLists.txt
+++ b/webview/CMakeLists.txt
@@ -199,15 +199,30 @@ elseif(PLATFORM_WINDOWS)
     target_include_directories(${LAUFEY_TARGET} PRIVATE
       ${WEBVIEW2_ROOT}/build/native/include
     )
-    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-      target_link_directories(${LAUFEY_TARGET} PRIVATE
-        ${WEBVIEW2_ROOT}/build/native/x64
-      )
+    # WebView2's NuGet package ships a separate loader import lib per arch under
+    # build/native/{x64,x86,arm64}. Pointer size can't tell x64 from arm64 (both
+    # 64-bit), so key off the compiler's actual target arch. MSVC_CXX_ARCHITECTURE_ID
+    # (X64/X86/ARM64) comes straight from cl.exe's target; fall back to the VS
+    # generator platform, then the system processor, then pointer size.
+    if(MSVC_CXX_ARCHITECTURE_ID)
+      set(_wv2_arch "${MSVC_CXX_ARCHITECTURE_ID}")
+    elseif(CMAKE_GENERATOR_PLATFORM)
+      set(_wv2_arch "${CMAKE_GENERATOR_PLATFORM}")
     else()
-      target_link_directories(${LAUFEY_TARGET} PRIVATE
-        ${WEBVIEW2_ROOT}/build/native/x86
-      )
+      set(_wv2_arch "${CMAKE_SYSTEM_PROCESSOR}")
     endif()
+    string(TOLOWER "${_wv2_arch}" _wv2_arch)
+    if(_wv2_arch MATCHES "arm64|aarch64")
+      set(_wv2_arch_dir "arm64")
+    elseif(_wv2_arch MATCHES "x64|amd64|x86_64" OR CMAKE_SIZEOF_VOID_P EQUAL 8)
+      set(_wv2_arch_dir "x64")
+    else()
+      set(_wv2_arch_dir "x86")
+    endif()
+    message(STATUS "WebView2 loader arch: ${_wv2_arch_dir}")
+    target_link_directories(${LAUFEY_TARGET} PRIVATE
+      ${WEBVIEW2_ROOT}/build/native/${_wv2_arch_dir}
+    )
   endif()
 
   target_link_libraries(${LAUFEY_TARGET}

--- a/webview/build_win.bat
+++ b/webview/build_win.bat
@@ -1,5 +1,12 @@
 @echo off
-call "C:\Program Files\Microsoft Visual Studio\18\Community\VC\Auxiliary\Build\vcvarsall.bat" x64
+setlocal
+rem First arg selects the vcvarsall target arch (default x64). Use "arm64" on a
+rem native ARM64 host or "amd64_arm64" to cross-compile from x64. CMake picks the
+rem matching WebView2 loader dir from the resulting toolchain automatically.
+set "VS_ARCH=%~1"
+if "%VS_ARCH%"=="" set "VS_ARCH=x64"
+
+call "C:\Program Files\Microsoft Visual Studio\18\Community\VC\Auxiliary\Build\vcvarsall.bat" %VS_ARCH%
 if errorlevel 1 (
     echo Failed to set up VS environment
     exit /b 1


### PR DESCRIPTION
Closes #42.

Enables ARM64 Windows builds for the **winit** and **webview** backends. WebView2 already supports ARM64 (Microsoft ships an ARM64 runtime, and the vendored `Microsoft.Web.WebView2` NuGet package includes an `arm64` loader), so the blockers were all x64-hardcoded build plumbing rather than the code itself.

## Changes

- **`webview/CMakeLists.txt`** — Select the WebView2 loader import lib by the compiler's actual target arch (`MSVC_CXX_ARCHITECTURE_ID` → generator platform → system processor → pointer-size fallback), linking `build/native/{arm64,x64,x86}`. The old `CMAKE_SIZEOF_VOID_P EQUAL 8` check couldn't tell x64 from arm64 (both 64-bit) and wrongly linked the x64 loader on ARM64. **This is the fix that makes an ARM64 webview build link.**
- **`capi/build.rs`** — Derive bindgen's clang target triple from `CARGO_CFG_TARGET_ARCH` instead of hardcoding `x86_64-pc-windows-msvc`. (Layouts are identical since both are LLP64, but the hardcode was still wrong.)
- **`webview/build_win.bat`** — Parameterize the `vcvarsall` target arch (default `x64`; pass `arm64` on a native ARM64 host or `amd64_arm64` to cross-compile).
- **`Makefile`** — Detect `aarch64` on Windows the way the macOS/Linux branches already do (`windowsarm64` CEF dist, `PROJ_ARCH := $(HOST_ARCH)`).
- **`.github/workflows/ci.yml`** — Add `aarch64-pc-windows-msvc` / `windows-11-arm` legs to the **winit** and **webview** matrices, matching the `msvc-dev-cmd` arch to the runner. **CEF-on-ARM64 is intentionally left out** — it needs the `windowsarm64` dist plus more plumbing and is best done as a dedicated follow-up.

## Verification

- `capi` crate builds clean (build.rs compiles).
- `ci.yml` parses as valid YAML.
- The end-to-end ARM64 webview link can't be exercised from Linux; the new CI legs cover it, and @WyattBlue offered to test on real ARM64 hardware in #42.

## Scope / follow-ups

Work tiers by difficulty: **winit** (CI target only) and **webview** (this PR) → **CEF on ARM64** (separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)