### PR TITLE
fix(winit): getNativeWindow crash and 0x0 surface on raw backend

### DIFF
--- a/backend-winit-common/src/lib.rs
+++ b/backend-winit-common/src/lib.rs
@@ -12,9 +12,10 @@ use std::collections::HashMap;
 use std::env;
 use std::ffi::{c_char, c_int, c_void, CStr, CString};
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicI32, AtomicPtr, AtomicU32, Ordering};
-use std::sync::Mutex;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Condvar, Mutex};
 use std::thread;
+use std::time::Duration;
 
 use libloading::{Library, Symbol};
 use muda::MenuEvent;
@@ -1171,16 +1172,50 @@ pub fn allocate_window_id() -> u32 {
 
 // --- Per-window handle storage ---
 
-static WINDOW_HANDLES: Mutex<Option<HashMap<u32, WindowHandleInfo>>> =
-  Mutex::new(None);
-static DISPLAY_HANDLE: AtomicPtr<c_void> = AtomicPtr::new(std::ptr::null_mut());
-static WINDOW_HANDLE_TYPE: AtomicI32 = AtomicI32::new(0);
-
+/// Native handles for a single window. Stored per `window_id` (not as
+/// process-wide globals) so multi-window setups return the right handle, and
+/// populated by `store_window_handles` only once the OS window actually
+/// exists.
 struct WindowHandleInfo {
   handle: *mut c_void,
+  display: *mut c_void,
+  handle_type: c_int,
 }
 
 unsafe impl Send for WindowHandleInfo {}
+
+static WINDOW_HANDLES: Mutex<Option<HashMap<u32, WindowHandleInfo>>> =
+  Mutex::new(None);
+/// Signalled by `store_window_handles` so getters blocked in
+/// `wait_for_window_handle` wake as soon as an entry appears.
+static WINDOW_HANDLES_CV: Condvar = Condvar::new();
+
+/// The winit/raw backend creates OS windows asynchronously: `create_window`
+/// posts a `CreateWindow` event and returns immediately, while the actual
+/// `winit::Window` (and its native handle) is built later on the event-loop
+/// thread. The runtime thread that answers `getNativeWindow()` therefore races
+/// window creation. Rather than returning an uninitialised handle (which
+/// surfaced as "unknown Laufey window handle type: 0"), block the caller until
+/// `store_window_handles` has recorded this window, up to a bounded timeout.
+fn wait_for_window_handle<R>(
+  window_id: u32,
+  f: impl FnOnce(&WindowHandleInfo) -> R,
+  default: R,
+) -> R {
+  // Bounded so a window that never materialises (e.g. a create event that was
+  // dropped, or a getter called after close) can't wedge the runtime thread.
+  let timeout = Duration::from_secs(5);
+  let guard = WINDOW_HANDLES.lock().unwrap();
+  let (guard, _timed_out) = WINDOW_HANDLES_CV
+    .wait_timeout_while(guard, timeout, |map| {
+      map.as_ref().is_none_or(|m| !m.contains_key(&window_id))
+    })
+    .unwrap();
+  match guard.as_ref().and_then(|m| m.get(&window_id)) {
+    Some(info) => f(info),
+    None => default,
+  }
+}
 
 /// # Safety
 /// Caller must pass valid pointers as defined by the LAUFEY C API contract.
@@ -1188,58 +1223,73 @@ pub unsafe extern "C" fn backend_get_window_handle(
   _data: *mut c_void,
   window_id: u32,
 ) -> *mut c_void {
-  let map = WINDOW_HANDLES.lock().unwrap();
-  map
-    .as_ref()
-    .and_then(|m| m.get(&window_id))
-    .map(|info| info.handle)
-    .unwrap_or(std::ptr::null_mut())
+  wait_for_window_handle(window_id, |info| info.handle, std::ptr::null_mut())
 }
 
 /// # Safety
 /// Caller must pass valid pointers as defined by the LAUFEY C API contract.
 pub unsafe extern "C" fn backend_get_display_handle(
   _data: *mut c_void,
-  _window_id: u32,
+  window_id: u32,
 ) -> *mut c_void {
-  DISPLAY_HANDLE.load(Ordering::Acquire)
+  wait_for_window_handle(window_id, |info| info.display, std::ptr::null_mut())
 }
 
 /// # Safety
 /// Caller must pass valid pointers as defined by the LAUFEY C API contract.
 pub unsafe extern "C" fn backend_get_window_handle_type(
   _data: *mut c_void,
-  _window_id: u32,
+  window_id: u32,
 ) -> c_int {
-  WINDOW_HANDLE_TYPE.load(Ordering::Acquire)
+  wait_for_window_handle(
+    window_id,
+    |info| info.handle_type,
+    LAUFEY_WINDOW_HANDLE_UNKNOWN,
+  )
 }
 
 pub fn store_window_handles(window_id: u32, window: &Window) {
   let mut handle_ptr = std::ptr::null_mut();
+  let mut display_ptr = std::ptr::null_mut();
+  let mut handle_type = LAUFEY_WINDOW_HANDLE_UNKNOWN;
 
   if let Ok(wh) = window.window_handle() {
     match wh.as_raw() {
       #[cfg(target_os = "macos")]
       RawWindowHandle::AppKit(handle) => {
         handle_ptr = handle.ns_view.as_ptr();
-        WINDOW_HANDLE_TYPE
-          .store(LAUFEY_WINDOW_HANDLE_APPKIT, Ordering::Release);
+        handle_type = LAUFEY_WINDOW_HANDLE_APPKIT;
       }
       #[cfg(target_os = "windows")]
       RawWindowHandle::Win32(handle) => {
         handle_ptr = handle.hwnd.get() as *mut c_void;
-        WINDOW_HANDLE_TYPE.store(LAUFEY_WINDOW_HANDLE_WIN32, Ordering::Release);
+        handle_type = LAUFEY_WINDOW_HANDLE_WIN32;
       }
       #[cfg(target_os = "linux")]
       RawWindowHandle::Xlib(handle) => {
         handle_ptr = handle.window as *mut c_void;
-        WINDOW_HANDLE_TYPE.store(LAUFEY_WINDOW_HANDLE_X11, Ordering::Release);
+        handle_type = LAUFEY_WINDOW_HANDLE_X11;
       }
       #[cfg(target_os = "linux")]
       RawWindowHandle::Wayland(handle) => {
         handle_ptr = handle.surface.as_ptr();
-        WINDOW_HANDLE_TYPE
-          .store(LAUFEY_WINDOW_HANDLE_WAYLAND, Ordering::Release);
+        handle_type = LAUFEY_WINDOW_HANDLE_WAYLAND;
+      }
+      _ => {}
+    }
+  }
+
+  if let Ok(dh) = window.display_handle() {
+    match dh.as_raw() {
+      #[cfg(target_os = "linux")]
+      RawDisplayHandle::Xlib(handle) => {
+        if let Some(display) = handle.display {
+          display_ptr = display.as_ptr();
+        }
+      }
+      #[cfg(target_os = "linux")]
+      RawDisplayHandle::Wayland(handle) => {
+        display_ptr = handle.display.as_ptr();
       }
       _ => {}
     }
@@ -1248,24 +1298,17 @@ pub fn store_window_handles(window_id: u32, window: &Window) {
   {
     let mut map = WINDOW_HANDLES.lock().unwrap();
     let map = map.get_or_insert_with(HashMap::new);
-    map.insert(window_id, WindowHandleInfo { handle: handle_ptr });
+    map.insert(
+      window_id,
+      WindowHandleInfo {
+        handle: handle_ptr,
+        display: display_ptr,
+        handle_type,
+      },
+    );
   }
-
-  if let Ok(dh) = window.display_handle() {
-    match dh.as_raw() {
-      #[cfg(target_os = "linux")]
-      RawDisplayHandle::Xlib(handle) => {
-        if let Some(display) = handle.display {
-          DISPLAY_HANDLE.store(display.as_ptr(), Ordering::Release);
-        }
-      }
-      #[cfg(target_os = "linux")]
-      RawDisplayHandle::Wayland(handle) => {
-        DISPLAY_HANDLE.store(handle.display.as_ptr(), Ordering::Release);
-      }
-      _ => {}
-    }
-  }
+  // Wake any getter blocked waiting for this window to be created.
+  WINDOW_HANDLES_CV.notify_all();
 }
 
 pub fn remove_window_handles(window_id: u32) {
@@ -1638,6 +1681,12 @@ pub fn dispatch_menu_click_by_id(item_id: &str) -> bool {
 pub struct WindowState {
   pub pending_title: Mutex<Option<String>>,
   pub pending_size: Mutex<Option<(i32, i32)>>,
+  /// Authoritative current window size in physical pixels. Unlike
+  /// `pending_size` (a one-shot *requested* size that's consumed when applied),
+  /// this tracks the window's real dimensions: seeded at creation from
+  /// `inner_size()` and refreshed on every resize. Backs `get_window_size` so
+  /// it never reports 0x0 (which produced a 0x0 wgpu surface).
+  pub current_size: Mutex<Option<(i32, i32)>>,
   pub pending_position: Mutex<Option<(i32, i32)>>,
   pub pending_resizable: Mutex<Option<bool>>,
   pub pending_always_on_top: Mutex<Option<bool>>,
@@ -1658,6 +1707,7 @@ impl WindowState {
     Self {
       pending_title: Mutex::new(None),
       pending_size: Mutex::new(None),
+      current_size: Mutex::new(None),
       pending_position: Mutex::new(None),
       pending_resizable: Mutex::new(None),
       pending_always_on_top: Mutex::new(None),
@@ -1934,7 +1984,14 @@ macro_rules! define_common_backend_fns {
       let mut found = false;
       if let Some(state) = <$B as $crate::BackendAccess>::get() {
         if let Some(()) = state.common().with_window(window_id, |ws| {
-          if let Some((w, h)) = *ws.pending_size.lock().unwrap() {
+          // Prefer the authoritative current size; fall back to a not-yet-
+          // applied requested size (e.g. a `set_size` before the window exists).
+          let size = ws
+            .current_size
+            .lock()
+            .unwrap()
+            .or(*ws.pending_size.lock().unwrap());
+          if let Some((w, h)) = size {
             if !width.is_null() {
               *width = w;
             }
@@ -3017,6 +3074,18 @@ pub fn apply_pending_attrs(
 
 /// Apply post-creation pending state (e.g. always-on-top).
 pub fn apply_pending_post_create(ws: &WindowState, window: &Window) {
+  // Seed the authoritative size from the window's real dimensions so
+  // `get_window_size` returns a valid value immediately after creation.
+  // Without this it read `pending_size` as 0x0 until a `Resized` event happened
+  // to arrive — reliable on X11, racy on Wayland — which left
+  // `getNativeWindow()` handing wgpu a 0x0 surface ("surface is not configured
+  // for presentation").
+  let size = window.inner_size();
+  if size.width > 0 && size.height > 0 {
+    *ws.current_size.lock().unwrap() =
+      Some((size.width as i32, size.height as i32));
+  }
+
   if let Some(true) = *ws.pending_always_on_top.lock().unwrap() {
     window.set_window_level(WindowLevel::AlwaysOnTop);
   }

--- a/examples/native_e2e/src/lib.rs
+++ b/examples/native_e2e/src/lib.rs
@@ -117,6 +117,25 @@ fn e2e_main() {
 
     check("window id is nonzero", win.id() != 0);
 
+    // ---- race probe: native handle immediately after creation ------------
+    // Regression guard for denoland/deno#35785. The winit/raw backend creates
+    // the OS window asynchronously, so reading the handle *right now* — with no
+    // wait — is exactly the race that returned an uninitialized type 0
+    // ("unknown Laufey window handle type: 0"). The getter must block until the
+    // window exists and hand back the real type. Capability-probed: backends
+    // that don't expose native handles legitimately return null/UNKNOWN.
+    let early_handle = win.get_window_handle();
+    if early_handle.is_null() {
+      na("early window handle (backend doesn't expose native handles)");
+    } else {
+      let (label, accepted) = expected_handle_type();
+      let ht = win.get_window_handle_type();
+      check(
+        &format!("early handle type resolved without racing (want {label}, got {ht})"),
+        accepted.contains(&ht),
+      );
+    }
+
     // Give the backend a moment to realize the window on screen.
     tokio::time::sleep(std::time::Duration::from_millis(300)).await;
 

--- a/winit/src/main.rs
+++ b/winit/src/main.rs
@@ -278,7 +278,7 @@ impl ApplicationHandler<UserEvent> for App {
       }
       WindowEvent::Resized(PhysicalSize { width, height }) => {
         state.common.with_window(laufey_id, |ws| {
-          *ws.pending_size.lock().unwrap() =
+          *ws.current_size.lock().unwrap() =
             Some((width as i32, height as i32));
         });
         laufey_backend_winit_common::dispatch_resize_event(


### PR DESCRIPTION
Fixes two bugs in the winit (`raw`) backend that made WebGPU-into-window unusable via `win.getNativeWindow()`, as reported in [denoland/deno#35785](https://github.com/denoland/deno/issues/35785).

## 1. Handle-type race → `unknown Laufey window handle type: 0`

Window creation is asynchronous: `create_window` posts a `CreateWindow` event and returns immediately, while the OS window (and its native handle) is built later on the event-loop thread via `store_window_handles`. The runtime thread that answers `getNativeWindow()` runs concurrently, so it could read the handle type **before the window existed** and get the uninitialised default `0` (`LAUFEY_WINDOW_HANDLE_UNKNOWN`), which deno surfaces as `unknown Laufey window handle type: 0`.

The handle *type* and *display* handle were also process-global statics that ignored `window_id`, so they returned the wrong value with more than one window (only the handle pointer was per-window).

**Fix:** store handle + display + type **per-window**, and block the getters on a `Condvar` until `store_window_handles` records the window — with a bounded timeout so a window that never materialises can't wedge the runtime thread.

## 2. `get_window_size` returned `0x0` → `surface is not configured for presentation`

`get_window_size` read `pending_size` — a one-shot *requested* size that is consumed (`take()`) when applied to the window and only re-populated by a later `Resized` event. That event is reliable on X11 but racy on Wayland, so the getter often returned `0x0`, and `getNativeWindow()` then handed wgpu a zero-sized surface (black window + "surface is not configured for presentation").

**Fix:** add an authoritative `current_size` (physical pixels) seeded from `inner_size()` at creation and refreshed on every resize. `get_window_size` reads it, falling back to a not-yet-applied requested size.

## Verification

Ran the exact deno#35785 repro (`new Deno.BrowserWindow()` → `requestAdapter`/`requestDevice` → `getNativeWindow()` → configure + render loop) end-to-end through `deno desktop --backend raw`:

- Before: `unknown Laufey window handle type: 0` (bug 1); after wiring that up, black window + "surface is not configured for presentation" (bug 2).
- After: `getNativeWindow() OK`, WebGPU renders into the window on **both X11 and native Wayland**, thousands of frames, no errors.

Also adds an immediate post-creation handle probe to the `native_e2e` battery as a regression guard for bug 1 (reads the handle with no wait — the exact race — and asserts a real type instead of `0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)