### PR TITLE
fix(webview/macos): honor TRANSPARENT_TITLEBAR flag

### DIFF
--- a/webview/src/webview_macos.mm
+++ b/webview/src/webview_macos.mm
@@ -782,6 +782,9 @@ void WKWebViewBackend::CreateWindowEx(uint32_t window_id, int width, int height,
       bool frameless = (flags & LAUFEY_WINDOW_FLAG_FRAMELESS) != 0;
       bool no_activate = (flags & LAUFEY_WINDOW_FLAG_NO_ACTIVATE) != 0;
       bool transparent = (flags & LAUFEY_WINDOW_FLAG_TRANSPARENT) != 0;
+      // Ignored on a frameless window, which has no title bar to begin with.
+      bool transparent_titlebar =
+          !frameless && (flags & LAUFEY_WINDOW_FLAG_TRANSPARENT_TITLEBAR) != 0;
 
       NSRect frame = NSMakeRect(0, 0, width, height);
       NSWindowStyleMask style = NSWindowStyleMaskClosable |
@@ -792,6 +795,11 @@ void WKWebViewBackend::CreateWindowEx(uint32_t window_id, int width, int height,
         style = NSWindowStyleMaskBorderless | NSWindowStyleMaskResizable;
       } else {
         style |= NSWindowStyleMaskTitled;
+      }
+      if (transparent_titlebar) {
+        // Let the content view extend the full height of the window, up under
+        // the title bar (made transparent below).
+        style |= NSWindowStyleMaskFullSizeContentView;
       }
 
       NSWindow* window;
@@ -830,6 +838,17 @@ void WKWebViewBackend::CreateWindowEx(uint32_t window_id, int width, int height,
       // an EXC_BAD_ACCESS (freed 0xa1a1a1a1 pattern) seconds after the window
       // closes. Opt out so ARC is the sole owner of the window's lifetime.
       [window setReleasedWhenClosed:NO];
+
+      if (transparent_titlebar) {
+        // Hidden/inset title bar (Electron `titleBarStyle: 'hidden'`): the web
+        // content fills the whole window, including the strip behind the title
+        // bar, which is made transparent with its text hidden so the standard
+        // traffic-light buttons float over the page. The app insets its own UI
+        // to clear the buttons. Mirrors the CEF backend's transparent-titlebar
+        // path (ConfigureNSWindowTransparentTitlebarForCefHandle).
+        window.titlebarAppearsTransparent = YES;
+        window.titleVisibility = NSWindowTitleHidden;
+      }
 
       [window center];
 


### PR DESCRIPTION
## Summary

The macOS system-WebView backend never read `LAUFEY_WINDOW_FLAG_TRANSPARENT_TITLEBAR`. A window requesting a transparent/hidden title bar fell through to a plain `NSWindowStyleMaskTitled` window, so the web content was inset below a normal title-bar band instead of filling the window with the traffic-light buttons overlaid.

The flag is already defined, documented, and implemented in the **CEF** backend (`ConfigureNSWindowTransparentTitlebarForCefHandle`). This just wires the same native `NSWindow` configuration into the WebView backend so the flag behaves consistently across both macOS backends:

- add `NSWindowStyleMaskFullSizeContentView` to the style mask, and
- set `titlebarAppearsTransparent = YES` + `titleVisibility = NSWindowTitleHidden`

when the flag is set (and the window is not frameless, which has no title bar to begin with).

No new API surface, no engine-feature emulation — just native AppKit calls laufey already makes in the sibling backend.

## Context

Reported downstream at denoland/deno#35635 (`deno desktop`, default `webview` backend on macOS): `transparentTitlebar` produced an inset title-bar band rather than full-bleed content — the "hiddenInset" editor-app chrome. This gives that on the WebView backend.

Note: the other half of that issue — dragging a frameless window via `-webkit-app-region: drag` — is **not** addressed here. WebKit does not implement `-webkit-app-region` (it works only under the Chromium/CEF backend), and that is an engine limitation we deliberately do not work around.

## Testing

macOS-only Objective-C++ change; not built in CI on Linux. Needs a build + manual check on macOS that a `TRANSPARENT_TITLEBAR` window renders full-bleed with traffic lights overlaid.