### PR TITLE
fix(webview/macos): frameless windows must become key + route input to WKWebView

### DIFF
--- a/webview/src/webview_macos.mm
+++ b/webview/src/webview_macos.mm
@@ -184,6 +184,22 @@ static void UnregisterNSWindow(NSWindow* win) {
   g_nswindow_to_laufey_id.erase((__bridge void*)win);
 }
 
+// A borderless NSWindow returns NO from -canBecomeKeyWindow/-canBecomeMainWindow
+// by default, so a frameless window never takes key focus and its WKWebView
+// never becomes first responder — killing all keyboard and mouse input. This
+// subclass forces both to YES so frameless windows behave like normal ones.
+@interface LaufeyKeyableWindow : NSWindow
+@end
+
+@implementation LaufeyKeyableWindow
+- (BOOL)canBecomeKeyWindow {
+  return YES;
+}
+- (BOOL)canBecomeMainWindow {
+  return YES;
+}
+@end
+
 @interface LaufeyScriptMessageHandler : NSObject <WKScriptMessageHandler>
 @property(nonatomic, assign) WKWebViewBackend* backend;
 @property(nonatomic, assign) uint32_t windowId;
@@ -814,6 +830,14 @@ void WKWebViewBackend::CreateWindowEx(uint32_t window_id, int width, int height,
                                   NSWindowCollectionBehaviorTransient |
                                   NSWindowCollectionBehaviorIgnoresCycle];
         window = panel;
+      } else if (frameless) {
+        // Borderless windows must be told they can become key/main, otherwise
+        // they receive no keyboard or mouse input (see LaufeyKeyableWindow).
+        window = [[LaufeyKeyableWindow alloc]
+            initWithContentRect:frame
+                      styleMask:style
+                        backing:NSBackingStoreBuffered
+                          defer:NO];
       } else {
         window = [[NSWindow alloc] initWithContentRect:frame
                                              styleMask:style
@@ -886,6 +910,8 @@ void WKWebViewBackend::CreateWindowEx(uint32_t window_id, int width, int height,
       }
 
       [window setContentView:webview];
+      // Route input into the web content once the window becomes key.
+      [window makeFirstResponder:webview];
 
       RegisterNSWindow(window, window_id);
 
@@ -1320,16 +1346,20 @@ void WKWebViewBackend::Show(uint32_t window_id) {
   dispatch_async(dispatch_get_main_queue(), ^{
     @autoreleasepool {
       NSWindow* win = nil;
+      WKWebView* web = nil;
       {
         std::lock_guard<std::mutex> lock(windows_mutex_);
         auto* state = GetWindow(window_id);
         if (state) {
           win = state->window;
+          web = state->webview;
         }
       }
       if (!win)
         return;
       [win makeKeyAndOrderFront:nil];
+      if (web)
+        [win makeFirstResponder:web];
     }
   });
 }
@@ -1356,16 +1386,20 @@ void WKWebViewBackend::Focus(uint32_t window_id) {
   dispatch_async(dispatch_get_main_queue(), ^{
     @autoreleasepool {
       NSWindow* win = nil;
+      WKWebView* web = nil;
       {
         std::lock_guard<std::mutex> lock(windows_mutex_);
         auto* state = GetWindow(window_id);
         if (state) {
           win = state->window;
+          web = state->webview;
         }
       }
       if (win) {
         [NSApp activateIgnoringOtherApps:YES];
         [win makeKeyAndOrderFront:nil];
+        if (web)
+          [win makeFirstResponder:web];
       }
     }
   });

--- a/webview/src/webview_macos.mm
+++ b/webview/src/webview_macos.mm
@@ -184,10 +184,11 @@ static void UnregisterNSWindow(NSWindow* win) {
   g_nswindow_to_laufey_id.erase((__bridge void*)win);
 }
 
-// A borderless NSWindow returns NO from -canBecomeKeyWindow/-canBecomeMainWindow
-// by default, so a frameless window never takes key focus and its WKWebView
-// never becomes first responder — killing all keyboard and mouse input. This
-// subclass forces both to YES so frameless windows behave like normal ones.
+// A borderless NSWindow returns NO from
+// -canBecomeKeyWindow/-canBecomeMainWindow by default, so a frameless window
+// never takes key focus and its WKWebView never becomes first responder —
+// killing all keyboard and mouse input. This subclass forces both to YES so
+// frameless windows behave like normal ones.
 @interface LaufeyKeyableWindow : NSWindow
 @end
 


### PR DESCRIPTION
## Problem

Frameless windows (`frameless: true`) on macOS received **no mouse or keyboard input** — buttons, checkboxes, Escape, and numeric shortcuts were all dead, even though the accessibility tree correctly exposed every control. This made a real integration (a macOS default-browser utility, Async Link) abandon the WKWebView backend entirely.

## Root cause

The frameless path builds a plain `NSWindow` with `NSWindowStyleMaskBorderless`. A borderless `NSWindow` returns `NO` from `-canBecomeKeyWindow` by default, so the window never becomes key → the `WKWebView` never becomes first responder → keyboard events and hit-tested clicks never reach web content. There was also no `makeFirstResponder:` call wiring the webview into the responder chain.

(The `no_activate` path already works because it uses `NSPanel`, which overrides `canBecomeKeyWindow` to `YES`; the CEF backend works because it keeps a titled window.)

## Fix

- Add a minimal `LaufeyKeyableWindow : NSWindow` subclass overriding `-canBecomeKeyWindow`/`-canBecomeMainWindow` to return `YES`, used for the borderless/frameless branch only.
- Call `[window makeFirstResponder:webview]` after `setContentView:` and in `Show`/`Focus`, so a key window routes input into the webview.

Titled and `NSPanel` paths are untouched. Builds + links clean.

