### PR TITLE
build: strip Linux CEF release binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -431,6 +431,7 @@ jobs:
           elif [[ "${{ runner.os }}" == "Windows" ]]; then
             cd cef/build/Release && 7z a ../../../laufey-cef-${{ matrix.target }}.zip *
           else
+            strip --strip-unneeded cef/build/Release/libcef.so
             tar czf laufey-cef-${{ matrix.target }}.tar.gz -C cef/build/Release .
           fi
 


### PR DESCRIPTION
## Summary

Strip `libcef.so` before packaging Linux CEF release artifacts.

The Linux CEF distribution contains debug and unnecessary symbol data, making
downstream bundles significantly larger.

## Results

Tested with Laufey and CEF 150:

- `libcef.so`: 1.40 GB → 249 MB
- compressed x64 backend: 352 MB → 150 MB
- downstream AppImage: 451 MiB → 255 MiB

The resulting AppImage launched successfully and loaded the application normally.

macOS and Windows packaging are unchanged.
