### PR TITLE
Fix Windows WebView2 show reentrancy

### DIFF
--- a/webview/src/webview_windows.cc
+++ b/webview/src/webview_windows.cc
@@ -804,6 +804,7 @@ void WebView2Backend::OnEnvironmentReady(uint32_t window_id, HWND hwnd,
             RECT bounds;
             GetClientRect(hwnd, &bounds);
             controller->put_Bounds(bounds);
+            controller->put_IsVisible(TRUE);
 
             std::string initScript = BuildInitScript(
                 RuntimeLoader::GetInstance()->GetJsNamespace(),
@@ -1211,10 +1212,15 @@ bool WebView2Backend::IsVisible(uint32_t window_id) {
 }
 
 void WebView2Backend::Show(uint32_t window_id) {
-  std::lock_guard<std::mutex> lock(windows_mutex_);
-  auto* state = GetWindow(window_id);
-  if (state)
-    ShowWindow(state->hwnd, SW_SHOW);
+  HWND hwnd = nullptr;
+  {
+    std::lock_guard<std::mutex> lock(windows_mutex_);
+    auto* state = GetWindow(window_id);
+    if (state)
+      hwnd = state->hwnd;
+  }
+  if (hwnd)
+    ShowWindow(hwnd, SW_SHOW);
 }
 
 void WebView2Backend::Hide(uint32_t window_id) {


### PR DESCRIPTION
## Summary
- release `windows_mutex_` before calling `ShowWindow`, which can synchronously dispatch `WM_SIZE` and re-enter the backend
- explicitly make the WebView2 controller visible after it is created

## Windows failure mode
With the official Deno Desktop `Hello, desktop` example on Windows, the generated app opened a white window and then exited with `ucrtbase.dll` / `0xc0000409`.

A crash dump showed an uncaught `std::system_error` (`resource deadlock would occur`): `ShowWindow()` synchronously delivered `WM_SIZE` while `windows_mutex_` was held, and the handler tried to acquire that mutex again. Capturing `HWND` under the lock and calling `ShowWindow()` after releasing it prevents the re-entrant lock attempt.

The initial parent window is hidden in this flow. Explicit `put_IsVisible(TRUE)` makes the controller surface render once the window is shown.

## Validation
- Windows 11 build 26100
- Deno `2.9.3+01c89b8` (canary)
- WebView2 Runtime `150.0.4078.83`
- Release build of Laufey v0.5.0
- Packaged `deno desktop main.ts` app remained running and served/rendered the expected `Hello, desktop` page

Related Deno report: denoland/deno#35755