### PR TITLE
Fix Windows WebView2 DPI awareness

### DIFF
--- a/webview/src/main_windows.cc
+++ b/webview/src/main_windows.cc
@@ -14,6 +14,7 @@
 
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
                    LPSTR lpCmdLine, int nCmdShow) {
+  SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
   CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
 
   std::string runtimePath;


### PR DESCRIPTION
## Summary
Configure the Windows host as per-monitor DPI aware before COM and WebView2 initialization.

Without an explicit DPI awareness context, the process runs as `PROCESS_DPI_UNAWARE`. Windows then DPI-virtualizes the window, which makes WebView2-rendered text and controls visibly soft.

## Validation
I built two otherwise identical Windows hosts and ran both against the same packaged Deno Desktop runtime and the same local `Desktop Preview` UI:

| Variant | `GetProcessDpiAwareness` result |
| --- | --- |
| Without this call | `PROCESS_DPI_UNAWARE` |
| With this call | `PROCESS_PER_MONITOR_DPI_AWARE` |

The DPI-aware variant rendered noticeably sharper text, inputs, and controls in a side-by-side comparison.

Test environment: Windows 11 build 26100, WebView2 Runtime 150.0.4078.83.
left: before change, right: after change
<img width="1172" height="670" alt="比較" src="https://github.com/user-attachments/assets/96f23af3-f4c6-42f7-a972-13d986cb3ce9" />

