### PR TITLE
fix(cef): report Linux focus through window activation

### DIFF
--- a/cef/src/app.cc
+++ b/cef/src/app.cc
@@ -87,6 +87,13 @@ cef_state_t LaufeyWindowDelegate::AcceptsFirstMouse(
 }
 
 #if defined(__linux__)
+void LaufeyWindowDelegate::OnWindowActivationChanged(
+    CefRefPtr<CefWindow> window, bool active) {
+  if (laufey_id_ > 0) {
+    RuntimeLoader::GetInstance()->DispatchFocusedEvent(laufey_id_, active);
+  }
+}
+
 bool LaufeyWindowDelegate::GetLinuxWindowProperties(
     CefRefPtr<CefWindow> window, CefLinuxWindowProperties& properties) {
   if (g_app_id.empty()) {

--- a/cef/src/app.h
+++ b/cef/src/app.h
@@ -97,6 +97,11 @@ class LaufeyWindowDelegate : public CefWindowDelegate {
   cef_state_t AcceptsFirstMouse(CefRefPtr<CefWindow> window) override;
 
 #if defined(__linux__)
+  // CEF Views reports activation on both X11 and Wayland. Use this instead of
+  // the X11-only XI2 monitor so focus events work with either Ozone backend.
+  void OnWindowActivationChanged(CefRefPtr<CefWindow> window,
+                                 bool active) override;
+
   // Advertise the Wayland app_id / X11 WM_CLASS (from g_app_id) so window
   // managers can attribute the right `.desktop` file — and therefore the right
   // taskbar/overview icon — to our windows. Without this the app_id defaults to

--- a/cef/src/main_linux.cc
+++ b/cef/src/main_linux.cc
@@ -158,20 +158,6 @@ static bool ResolveWindow(XIDeviceEvent* dev, uint32_t* out_wid, double* out_x,
   return true;
 }
 
-// Resolve a window XID from an XI2 enter/focus event to a laufey ID.
-static uint32_t ResolveLaufeyId(Window xid) {
-  if (!xid)
-    return 0;
-  RuntimeLoader* loader = RuntimeLoader::GetInstance();
-  uint32_t wid = loader->GetLaufeyIdForNativeHandle((void*)(uintptr_t)xid);
-  if (wid == 0) {
-    auto it = g_frame_cache.find(xid);
-    if (it != g_frame_cache.end())
-      wid = it->second.laufey_id;
-  }
-  return wid;
-}
-
 static void ProcessXI2Event(XEvent* xev) {
   if (!XGetEventData(xev->xcookie.display, &xev->xcookie))
     return;
@@ -285,13 +271,6 @@ static void ProcessXI2Event(XEvent* xev) {
             g_hover_wid, LAUFEY_MOUSE_RELEASED, laufey_button, g_hover_x,
             g_hover_y, g_hover_modifiers, g_click_tracker.count);
       }
-    }
-  } else if (evtype == XI_FocusIn || evtype == XI_FocusOut) {
-    XIEnterEvent* enter = static_cast<XIEnterEvent*>(xev->xcookie.data);
-    Window target = enter->child ? enter->child : enter->event;
-    uint32_t wid = ResolveLaufeyId(target);
-    if (wid > 0) {
-      loader->DispatchFocusedEvent(wid, evtype == XI_FocusIn ? 1 : 0);
     }
   }
 
@@ -562,8 +541,6 @@ void MonitorLinuxWindowEvents(unsigned long xid) {
   XISetMask(mask_bits, XI_Motion);
   XISetMask(mask_bits, XI_Enter);
   XISetMask(mask_bits, XI_Leave);
-  XISetMask(mask_bits, XI_FocusIn);
-  XISetMask(mask_bits, XI_FocusOut);
 
   XIEventMask xi_mask;
   xi_mask.deviceid = XIAllMasterDevices;


### PR DESCRIPTION
Use CEF's window activation callback for Linux focus events.

This fixes focus and blur events under native Wayland. XI2 focus handling is removed to avoid duplicate events on X11.

Tested for over a week through [`pi-ui`](https://github.com/hyperpuncher/pi-ui) on X11 and native Wayland.
