### PR TITLE
Inject bindings bridge into the main frame only

### DIFF
--- a/cef/src/app.cc
+++ b/cef/src/app.cc
@@ -404,6 +404,15 @@ bool LaufeyHandler::OnProcessMessageReceived(
   const std::string& name = message->GetName().ToString();
 
   if (name == "laufey_call") {
+    // Defense in depth: even though the renderer only installs the bridge in
+    // the main frame, a compromised renderer could forge a laufey_call from a
+    // sub-frame. Frame provenance is discarded once dispatched to the runtime
+    // (only the browser maps to a window id), so drop anything that is not the
+    // main frame here.
+    if (!frame || !frame->IsMain()) {
+      return true;
+    }
+
     CefRefPtr<CefListValue> args = message->GetArgumentList();
     uint64_t call_id = static_cast<uint64_t>(args->GetDouble(0));
     std::string method_path = args->GetString(1).ToString();

--- a/cef/src/render_process_handler.cc
+++ b/cef/src/render_process_handler.cc
@@ -157,6 +157,14 @@ void LaufeyRenderProcessHandler::OnBrowserCreated(
 void LaufeyRenderProcessHandler::OnContextCreated(
     CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame,
     CefRefPtr<CefV8Context> context) {
+  // Only the main frame receives the bridge. Cross-origin (or any sub-) frames
+  // must not inherit `window[ns]`; otherwise embedded content could invoke
+  // bindings that run with the host process's permissions. Mirrors the
+  // macOS/iOS WebView backends, which inject with forMainFrameOnly:YES.
+  if (!frame || !frame->IsMain()) {
+    return;
+  }
+
   CefRefPtr<CefV8Value> global = context->GetGlobal();
 
   std::string ns = "Laufey";

--- a/webview/src/webview_linux.cc
+++ b/webview/src/webview_linux.cc
@@ -735,8 +735,12 @@ void WebKitGTKBackend::CreateWindowEx(uint32_t window_id, int width, int height,
         "            method: path.join('.'),\n"
         "            args: processedArgs\n"
         "          }));");
+    // Inject the bridge into the top frame only. Cross-origin/sub frames must
+    // not inherit it; otherwise embedded content could invoke bindings running
+    // with the host process's permissions. Matches the macOS/iOS
+    // forMainFrameOnly:YES behavior.
     WebKitUserScript* script = webkit_user_script_new(
-        initScript.c_str(), WEBKIT_USER_CONTENT_INJECT_ALL_FRAMES,
+        initScript.c_str(), WEBKIT_USER_CONTENT_INJECT_TOP_FRAME,
         WEBKIT_USER_SCRIPT_INJECT_AT_DOCUMENT_START, nullptr, nullptr);
     webkit_user_content_manager_add_script(content_manager, script);
     webkit_user_script_unref(script);

--- a/webview/src/webview_windows.cc
+++ b/webview/src/webview_windows.cc
@@ -824,6 +824,29 @@ void WebView2Backend::OnEnvironmentReady(uint32_t window_id, HWND hwnd,
                     [this, wid](ICoreWebView2* sender,
                                 ICoreWebView2WebMessageReceivedEventArgs* args)
                         -> HRESULT {
+                      // The injected bridge script runs in every frame
+                      // (AddScriptToExecuteOnDocumentCreated cannot be scoped
+                      // to the main frame), so validate the message source
+                      // here: only accept messages whose document URI matches
+                      // the top-level document. This stops cross-origin/sub
+                      // frames from invoking bindings that run with the host
+                      // process's permissions.
+                      LPWSTR msgSource = nullptr;
+                      LPWSTR topSource = nullptr;
+                      args->get_Source(&msgSource);
+                      sender->get_Source(&topSource);
+                      bool from_main_frame = msgSource && topSource &&
+                                             wcscmp(msgSource, topSource) == 0;
+                      if (msgSource) {
+                        CoTaskMemFree(msgSource);
+                      }
+                      if (topSource) {
+                        CoTaskMemFree(topSource);
+                      }
+                      if (!from_main_frame) {
+                        return S_OK;
+                      }
+
                       LPWSTR messageRaw;
                       args->TryGetWebMessageAsString(&messageRaw);
                       if (messageRaw) {


### PR DESCRIPTION
## Summary

The native `bindings` bridge was being installed into **every** frame, including cross-origin and sub-frames, and frame identity was discarded before the call reached the runtime (a call was attributed only to the containing window). This restricts the bridge to the top/main frame across all affected backends, matching the behavior macOS and iOS already have via `forMainFrameOnly:YES`.

## Changes

- **CEF renderer** (`render_process_handler.cc`): skip bridge injection in `OnContextCreated` when the frame is not the main frame — sub-frames no longer receive `window[ns]` or the external-link interceptor.
- **CEF browser process** (`app.cc`): drop `laufey_call` messages that do not originate from the main frame, as a defense-in-depth check against a compromised renderer.
- **Linux WebKitGTK** (`webview_linux.cc`): inject the init script with `INJECT_TOP_FRAME` instead of `INJECT_ALL_FRAMES`.
- **Windows WebView2** (`webview_windows.cc`): `AddScriptToExecuteOnDocumentCreated` cannot be scoped to the main frame, so the `WebMessageReceived` handler now validates the source and drops any message whose document URI does not match the top-level document.

## Testing

- CEF backend builds and links cleanly on macOS (`ninja -C cef/build`).
- `CefFrame::IsMain()` and WebView2 `get_Source()` confirmed present in the vendored SDK headers.
- Linux/Windows edits are API-correct but were not compiled here (no cross-platform toolchain on this machine).

## Follow-up

No automated regression test yet — the repo has no cross-origin-iframe harness for the webview backends, which would need multiple origins and a browser-driven runner. Worth adding separately.