### PR TITLE
fix(macos): don't flip context menu Y in a flipped content view

### DIFF
--- a/cef/src/runtime_loader_mac.mm
+++ b/cef/src/runtime_loader_mac.mm
@@ -445,9 +445,13 @@ void Backend_ShowContextMenu_Mac(void* data, uint32_t window_id, int x, int y,
       return;
 
     NSView* contentView = [win contentView];
-    // Convert from top-left origin (laufey coordinates) to bottom-left origin
-    // (NSView)
-    NSPoint loc = NSMakePoint(x, [contentView frame].size.height - y);
+    // LAUFEY coordinates are window-relative with a top-left origin (the web
+    // convention). -popUpMenuPositioningItem:atLocation:inView: reads the
+    // location in the view's *own* coordinate system, which is top-left only
+    // when the view is flipped. Flipping unconditionally mirrors the menu
+    // about the window's midline whenever the content view already is.
+    NSPoint loc = NSMakePoint(
+        x, [contentView isFlipped] ? y : [contentView frame].size.height - y);
     [menu popUpMenuPositioningItem:nil atLocation:loc inView:contentView];
   });
 }

--- a/webview/src/webview_macos.mm
+++ b/webview/src/webview_macos.mm
@@ -1538,9 +1538,15 @@ void WKWebViewBackend::ShowContextMenu(uint32_t window_id, int x, int y,
       return;
 
     NSView* view = [win contentView];
-    // Convert from top-left origin (laufey coordinates) to bottom-left origin
-    // (NSView)
-    NSPoint loc = NSMakePoint(x, [view frame].size.height - y);
+    // LAUFEY coordinates are window-relative with a top-left origin (the web
+    // convention). -popUpMenuPositioningItem:atLocation:inView: reads the
+    // location in the view's *own* coordinate system, which is top-left only
+    // when the view is flipped. The content view here is the WKWebView, and
+    // -[WKWebView isFlipped] is YES, so flipping unconditionally put the menu
+    // at (height - y) — mirrored about the window's midline. Only convert for
+    // views that really are bottom-left.
+    NSPoint loc =
+        NSMakePoint(x, [view isFlipped] ? y : [view frame].size.height - y);
     [menu popUpMenuPositioningItem:nil atLocation:loc inView:view];
   });
 }


### PR DESCRIPTION
`show_context_menu` takes window-relative coordinates with a top-left origin — the space a caller naturally has on hand, since it's what a DOM mouse event's `clientX`/`clientY` are in. Both macOS backends converted that to a bottom-left origin before handing it to `-popUpMenuPositioningItem:atLocation:inView:`:

```objc
NSPoint loc = NSMakePoint(x, [view frame].size.height - y);
```

That method reads the location in the target view's *own* coordinate system, which is already top-left when the view is flipped. In the webview backend the content view **is** the WKWebView (`[window setContentView:webview]`), and `-[WKWebView isFlipped]` is `YES`, so the conversion was a second flip: the menu popped up mirrored about the window's midline.

Concretely, in an 800pt window a right-click at `clientY = 44` opened the menu at the bottom edge, and a click at `clientY = 755` opened it near the top. Callers were working around it by passing `windowHeight - clientY`.

Fixed by only converting for views that really are bottom-left:

```objc
NSPoint loc = NSMakePoint(x, [view isFlipped] ? y : [view frame].size.height - y);
```

Applied to both `webview/src/webview_macos.mm` and `cef/src/runtime_loader_mac.mm`. The CEF backend goes through `[[browserView window] contentView]`, which isn't necessarily flipped, so the guard keeps that path correct either way rather than swapping one hard-coded assumption for another.

### Verification

Built the webview backend and drove it from a Deno desktop app (600x800 window with labeled bands at y 0-100 and y 700-800), calling `showContextMenu` at known coordinates:

| probe | before | after |
| --- | --- | --- |
| `showContextMenu(200, 50)` | menu in the **bottom** band (y ~= 750) | menu at y ~= 50 |
| `showContextMenu(200, 740)` | menu near the top | menu at y ~= 740 |

Also confirmed `-[WKWebView isFlipped] == YES` (and plain `NSView` == `NO`) with a standalone AppKit probe, so the guard selects the intended branch.

CEF backend not built locally (needs the full CEF tarball); the edit is the same construct that compiles in the webview backend.

Refs denoland/deno#36379
