### PR TITLE
fix(webview): use wide default window procedure on Windows

### DIFF
--- a/webview/src/webview_windows.cc
+++ b/webview/src/webview_windows.cc
@@ -585,7 +585,7 @@ LRESULT CALLBACK WebView2Backend::WindowProc(HWND hwnd, UINT msg, WPARAM wParam,
     }
   }
 
-  return DefWindowProc(hwnd, msg, wParam, lParam);
+  return DefWindowProcW(hwnd, msg, wParam, lParam);
 }
 
 WebView2Backend::WebView2Backend() {


### PR DESCRIPTION
## Summary

- Route unhandled messages from the UTF-16 WebView2 window class through `DefWindowProcW`.
- Prevent the ANSI default procedure from interpreting UTF-16 `WM_SETTEXT` payloads as single-byte strings.
- Preserve full native window titles on Windows.

## Root Cause

`WNDCLASSEXW` registers a UTF-16 window class and title changes use `SetWindowTextW`. Without `UNICODE` defined, the generic `DefWindowProc` resolves to `DefWindowProcA`. When it handles `WM_SETTEXT`, the UTF-16 title begins with `L\0...`; the ANSI procedure sees the NUL byte after the first ASCII character and retains only that character.

## Validation

- `clang-format --dry-run --Werror webview/src/webview_windows.cc`
- `git diff --check`
- Configured and built the Windows WebView backend in Release with Visual Studio 2022 Build Tools and the WebView2 SDK.
- Launched the built backend with the existing `hello_runtime`; Windows reported the complete expected title: `LAUFEY - Bindings Demo`.

Fixes #60

This is not exptected window title. The text become garbled text.
<img width="778" height="590" alt="image" src="https://github.com/user-attachments/assets/5133909a-a75c-4a68-bb98-a7fa1d1c5ba5" />



