### PR TITLE
fix: correct macOS coordinate space and deliver bindings binary as Uint8Array

### DIFF
--- a/cef/src/render_process_handler.cc
+++ b/cef/src/render_process_handler.cc
@@ -306,6 +306,24 @@ uint64_t LaufeyRenderProcessHandler::GetNextCallId() {
   return next_call_id_++;
 }
 
+// CefV8Value has no native typed-array introspection, so detect
+// ArrayBufferViews structurally: anything whose `buffer` property is an
+// ArrayBuffer and that carries numeric byteOffset/byteLength is (or is
+// indistinguishable from) a typed array / DataView.
+static bool IsArrayBufferView(CefRefPtr<CefV8Value> v8val) {
+  if (!v8val || !v8val->IsObject()) {
+    return false;
+  }
+  CefRefPtr<CefV8Value> buffer = v8val->GetValue("buffer");
+  if (!buffer || !buffer->IsArrayBuffer()) {
+    return false;
+  }
+  CefRefPtr<CefV8Value> off = v8val->GetValue("byteOffset");
+  CefRefPtr<CefV8Value> len = v8val->GetValue("byteLength");
+  return off && len && (off->IsInt() || off->IsUInt() || off->IsDouble()) &&
+         (len->IsInt() || len->IsUInt() || len->IsDouble());
+}
+
 CefRefPtr<CefValue> LaufeyRenderProcessHandler::V8ValueToCefValue(
     CefRefPtr<CefV8Value> v8val) {
   CefRefPtr<CefValue> value = CefValue::Create();
@@ -327,6 +345,34 @@ CefRefPtr<CefValue> LaufeyRenderProcessHandler::V8ValueToCefValue(
       list->SetValue(i, V8ValueToCefValue(v8val->GetValue(i)));
     }
     value->SetList(list);
+  } else if (v8val->IsArrayBuffer()) {
+    // Must be checked before IsObject: an ArrayBuffer satisfies IsObject
+    // too, so the old object-branch-first ordering objectified binary
+    // arguments into {} (denoland/deno#36498).
+    void* data = v8val->GetArrayBufferData();
+    size_t len = v8val->GetArrayBufferByteLength();
+    if (data && len > 0) {
+      value->SetBinary(CefBinaryValue::Create(data, len));
+    } else {
+      value->SetNull();
+    }
+  } else if (IsArrayBufferView(v8val)) {
+    // Typed arrays (Uint8Array et al.) and DataView: copy the viewed byte
+    // range out of the underlying buffer. Without this they fell into the
+    // object branch and arrived as index-keyed dictionaries — wrong shape,
+    // and pathologically slow for large views (denoland/deno#36498).
+    CefRefPtr<CefV8Value> ab = v8val->GetValue("buffer");
+    auto* data = static_cast<uint8_t*>(ab->GetArrayBufferData());
+    size_t ab_len = ab->GetArrayBufferByteLength();
+    size_t off =
+        static_cast<size_t>(v8val->GetValue("byteOffset")->GetUIntValue());
+    size_t len =
+        static_cast<size_t>(v8val->GetValue("byteLength")->GetUIntValue());
+    if (data && len > 0 && off <= ab_len && len <= ab_len - off) {
+      value->SetBinary(CefBinaryValue::Create(data + off, len));
+    } else {
+      value->SetNull();
+    }
   } else if (v8val->IsObject()) {
     CefRefPtr<CefDictionaryValue> dict = CefDictionaryValue::Create();
     std::vector<CefString> keys;
@@ -335,14 +381,6 @@ CefRefPtr<CefValue> LaufeyRenderProcessHandler::V8ValueToCefValue(
       dict->SetValue(key, V8ValueToCefValue(v8val->GetValue(key)));
     }
     value->SetDictionary(dict);
-  } else if (v8val->IsArrayBuffer()) {
-    void* data = v8val->GetArrayBufferData();
-    size_t len = v8val->GetArrayBufferByteLength();
-    if (data && len > 0) {
-      value->SetBinary(CefBinaryValue::Create(data, len));
-    } else {
-      value->SetNull();
-    }
   } else {
     value->SetNull();
   }
@@ -372,9 +410,37 @@ CefRefPtr<CefV8Value> LaufeyRenderProcessHandler::CefValueToV8Value(
       size_t size = binary->GetSize();
       std::vector<uint8_t> buffer(size);
       binary->GetData(buffer.data(), size, 0);
+      // WithCopy: the plain CreateArrayBuffer externalizes the caller's
+      // memory without copying, and `buffer` dies at the end of this scope —
+      // the resulting ArrayBuffer pointed at freed stack memory.
       CefRefPtr<CefV8Value> arrayBuffer =
-          CefV8Value::CreateArrayBuffer(buffer.data(), size, nullptr);
-      return arrayBuffer ? arrayBuffer : CefV8Value::CreateNull();
+          CefV8Value::CreateArrayBufferWithCopy(buffer.data(), size);
+      if (!arrayBuffer) {
+        return CefV8Value::CreateNull();
+      }
+      // Wrap in a Uint8Array so pages receive the documented binding type
+      // (denoland/deno#36498). CefV8Value cannot construct typed arrays
+      // directly; Reflect.construct(Uint8Array, [ab]) does it without eval.
+      if (context) {
+        CefRefPtr<CefV8Value> global = context->GetGlobal();
+        CefRefPtr<CefV8Value> reflect =
+            global ? global->GetValue("Reflect") : nullptr;
+        CefRefPtr<CefV8Value> construct = reflect && reflect->IsObject()
+                                              ? reflect->GetValue("construct")
+                                              : nullptr;
+        CefRefPtr<CefV8Value> uint8_ctor = global->GetValue("Uint8Array");
+        if (construct && construct->IsFunction() && uint8_ctor &&
+            uint8_ctor->IsFunction()) {
+          CefRefPtr<CefV8Value> args_arr = CefV8Value::CreateArray(1);
+          args_arr->SetValue(0, arrayBuffer);
+          CefRefPtr<CefV8Value> view =
+              construct->ExecuteFunction(reflect, {uint8_ctor, args_arr});
+          if (view && !view->IsUndefined() && !view->IsNull()) {
+            return view;
+          }
+        }
+      }
+      return arrayBuffer;
     }
     case VTYPE_DICTIONARY: {
       CefRefPtr<CefDictionaryValue> dict = value->GetDictionary();

--- a/webview/src/init_script.h
+++ b/webview/src/init_script.h
@@ -113,7 +113,10 @@ inline std::string BuildInitScript(const std::string& ns,
               for (let i = 0; i < binary.length; i++) {
                 bytes[i] = binary.charCodeAt(i);
               }
-              return bytes.buffer;
+              // Deliver a Uint8Array, not its underlying ArrayBuffer —
+              // callers are documented to receive the same type they sent
+              // (denoland/deno#36498).
+              return bytes;
             }
             if (Array.isArray(obj)) {
               return obj.map(convertBinary);

--- a/webview/src/webview_macos.mm
+++ b/webview/src/webview_macos.mm
@@ -964,9 +964,16 @@ void WKWebViewBackend::CreateWindowEx(uint32_t window_id, int width, int height,
                   usingBlock:^(NSNotification* note) {
                     NSWindow* w = [note object];
                     if (w) {
+                      // Report top-left global coordinates, matching the
+                      // convention SetWindowPosition/GetWindowPosition use —
+                      // the raw Cocoa bottom-left origin previously leaked
+                      // through here (denoland/deno#36119).
                       NSRect f = [w frame];
+                      NSScreen* primary = [[NSScreen screens] firstObject];
+                      CGFloat screenH = primary ? primary.frame.size.height : 0;
                       RuntimeLoader::GetInstance()->DispatchMoveEvent(
-                          window_id, (int)f.origin.x, (int)f.origin.y);
+                          window_id, (int)f.origin.x,
+                          (int)(screenH - f.origin.y - f.size.height));
                     }
                   }];
 
@@ -1184,6 +1191,17 @@ void WKWebViewBackend::Quit() {
   });
 }
 
+// AppKit's global coordinate space is bottom-left-anchored to the *primary*
+// screen ([[NSScreen screens] firstObject], the one with the menu bar), while
+// the laufey API speaks top-left global coordinates. Converting against the
+// window's *current* screen — its local height, ignoring its global origin
+// offset — lands windows in the wrong place on any multi-display setup
+// (denoland/deno#36119). Always convert against the primary screen.
+static CGFloat PrimaryScreenHeight() {
+  NSScreen* primary = [[NSScreen screens] firstObject];
+  return primary ? primary.frame.size.height : 0;
+}
+
 void WKWebViewBackend::SetWindowSize(uint32_t window_id, int width,
                                      int height) {
   dispatch_async(dispatch_get_main_queue(), ^{
@@ -1191,9 +1209,11 @@ void WKWebViewBackend::SetWindowSize(uint32_t window_id, int width,
       std::lock_guard<std::mutex> lock(windows_mutex_);
       auto* state = GetWindow(window_id);
       if (state) {
-        NSRect frame = [state->window frame];
-        frame.size = NSMakeSize(width, height);
-        [state->window setFrame:frame display:YES];
+        // Content size, matching CreateWindow's initWithContentRect: —
+        // setting the *frame* size here made setSize(w, h) produce a window
+        // whose page area was smaller than an identically-sized CreateWindow
+        // by the title-bar height (denoland/deno#36119).
+        [state->window setContentSize:NSMakeSize(width, height)];
       }
     }
   });
@@ -1206,9 +1226,12 @@ void WKWebViewBackend::GetWindowSize(uint32_t window_id, int* width,
     std::lock_guard<std::mutex> lock(windows_mutex_);
     auto* state = GetWindow(window_id);
     if (state) {
-      NSRect frame = [state->window frame];
-      w = static_cast<int>(frame.size.width);
-      h = static_cast<int>(frame.size.height);
+      // Content size, for symmetry with CreateWindow / SetWindowSize and the
+      // resize event.
+      NSRect content =
+          [state->window contentRectForFrameRect:[state->window frame]];
+      w = static_cast<int>(content.size.width);
+      h = static_cast<int>(content.size.height);
     }
   });
   if (width)
@@ -1224,8 +1247,7 @@ void WKWebViewBackend::SetWindowPosition(uint32_t window_id, int x, int y) {
       auto* state = GetWindow(window_id);
       if (state) {
         NSRect frame = [state->window frame];
-        NSRect screenFrame = [[state->window screen] frame];
-        CGFloat flippedY = screenFrame.size.height - y - frame.size.height;
+        CGFloat flippedY = PrimaryScreenHeight() - y - frame.size.height;
         [state->window setFrameOrigin:NSMakePoint(x, flippedY)];
       }
     }
@@ -1239,9 +1261,8 @@ void WKWebViewBackend::GetWindowPosition(uint32_t window_id, int* x, int* y) {
     auto* state = GetWindow(window_id);
     if (state) {
       NSRect frame = [state->window frame];
-      NSRect screenFrame = [[state->window screen] frame];
       px = static_cast<int>(frame.origin.x);
-      py = static_cast<int>(screenFrame.size.height - frame.origin.y -
+      py = static_cast<int>(PrimaryScreenHeight() - frame.origin.y -
                             frame.size.height);
     }
   });


### PR DESCRIPTION
Two clusters of fixes, verified end-to-end via `deno desktop` with `LAUFEY_DEV_DIR` on macOS.

## macOS webview coordinate/size fixes (denoland/deno#36119)

- **`SetWindowPosition` / `GetWindowPosition` / move event**: AppKit's global space is bottom-left-anchored to the *primary* screen, but the conversion used the window's *current* screen — wrong height and no account of the screen's global origin offset, so `setPosition(50, 50)` landed windows on the wrong display entirely in multi-monitor setups. The move event additionally leaked raw Cocoa bottom-left coordinates with no conversion at all. All three now convert against the primary screen.
- **`SetWindowSize` / `GetWindowSize`**: now use content size, matching `CreateWindow`'s `initWithContentRect:` and the resize event. Previously `setSize(w, h)` set the *frame* size, making the page area shorter than an identically-sized `CreateWindow` by the title-bar height, and `getSize` disagreed with both the constructor and the resize event.

After the fix: `setPosition(50,50)` → `getPosition() == [50,50]` == move-event detail; constructor `{width:500,height:400}` → `getSize() == [500,400]` == resize-event detail.

## Bindings binary values (denoland/deno#36498)

denoland/deno#36573 fixes the runtime side so binding args/results carry binary instead of erroring; these are the backend-side gaps:

- **webview**: the init script's `convertBinary` returned `bytes.buffer` — pages received an `ArrayBuffer` instead of the documented `Uint8Array`.
- **cef**: `V8ValueToCefValue` checked `IsObject` before `IsArrayBuffer` (an ArrayBuffer satisfies `IsObject`), so binary arguments were objectified into index-keyed dictionaries; typed arrays (`Uint8Array` et al.) weren't handled at all. Now ArrayBuffers convert first and ArrayBufferViews copy their viewed byte range. `CefValueToV8Value` materializes `VTYPE_BINARY` as a `Uint8Array` via `Reflect.construct`.
- **cef UAF**: `CreateArrayBuffer(buffer.data(), size, nullptr)` externalizes the caller's memory without copying, and `buffer` was a stack vector destroyed at scope end — the resulting ArrayBuffer pointed at freed memory. Switched to `CreateArrayBufferWithCopy`.

Both backends build (`make webview`, `make cef`, macOS arm64); webview verified at runtime (binary round-trips as `Uint8Array` with correct bytes both directions).

https://claude.ai/code/session_016w9C7umSW1KUYa7eXwSXRo