### PR TITLE
fix(windows): use wide Win32 APIs for runtime library paths (non-ASCII path support)

### DIFF
--- a/backend-common/CMakeLists.txt
+++ b/backend-common/CMakeLists.txt
@@ -62,6 +62,7 @@ elseif(UNIX)
   )
 elseif(WIN32)
   list(APPEND LAUFEY_COMMON_SRCS
+    src/strings_win.cc
     src/notifications_win.cc
     src/dialog_win.cc
     src/clipboard_win.cc

--- a/backend-common/include/laufey_backend_common.h
+++ b/backend-common/include/laufey_backend_common.h
@@ -21,6 +21,20 @@
 
 namespace laufey_common {
 
+#ifdef _WIN32
+// ---------------------------------------------------------------------------
+// Win32 string conversion
+// ---------------------------------------------------------------------------
+//
+// Strings cross the C API and flow through both backends as UTF-8, while the
+// wide (*W) Win32 APIs want UTF-16; the ANSI (*A) APIs would garble non-ASCII
+// text in the active codepage. Every conversion goes through this one pair of
+// helpers so a future fix (e.g. long-path prefixing) lands in one place.
+
+std::wstring Utf8ToWide(const std::string& s);
+std::string WideToUtf8(const std::wstring& w);
+#endif
+
 // ---------------------------------------------------------------------------
 // Notifications
 // ---------------------------------------------------------------------------

--- a/backend-common/src/clipboard_win.cc
+++ b/backend-common/src/clipboard_win.cc
@@ -15,18 +15,6 @@ namespace laufey_common {
 
 namespace {
 
-std::wstring Utf8ToWide(const std::string& s) {
-  if (s.empty())
-    return std::wstring();
-  int n = MultiByteToWideChar(CP_UTF8, 0, s.c_str(), -1, nullptr, 0);
-  std::wstring out;
-  if (n > 0) {
-    out.resize(n - 1);
-    MultiByteToWideChar(CP_UTF8, 0, s.c_str(), -1, out.data(), n);
-  }
-  return out;
-}
-
 char* WideToUtf8Strdup(const wchar_t* w) {
   if (!w)
     return nullptr;

--- a/backend-common/src/dialog_win.cc
+++ b/backend-common/src/dialog_win.cc
@@ -14,22 +14,6 @@
 
 namespace laufey_common {
 
-namespace {
-
-std::wstring Utf8ToWide(const std::string& s) {
-  if (s.empty())
-    return std::wstring();
-  int n = MultiByteToWideChar(CP_UTF8, 0, s.c_str(), -1, nullptr, 0);
-  std::wstring out;
-  if (n > 0) {
-    out.resize(n - 1);
-    MultiByteToWideChar(CP_UTF8, 0, s.c_str(), -1, out.data(), n);
-  }
-  return out;
-}
-
-}  // namespace
-
 int ShowDialogWin(int dialog_type, const std::string& title,
                   const std::string& message,
                   const std::string& default_value, char** out_input_value) {

--- a/backend-common/src/notifications_win.cc
+++ b/backend-common/src/notifications_win.cc
@@ -230,18 +230,6 @@ HWND EnsureNotifMessageWindow() {
   return g_notif_msg_hwnd;
 }
 
-std::wstring Utf8ToWide(const std::string& s) {
-  if (s.empty())
-    return std::wstring();
-  int n = MultiByteToWideChar(CP_UTF8, 0, s.c_str(), -1, nullptr, 0);
-  std::wstring out;
-  if (n > 0) {
-    out.resize(n - 1);
-    MultiByteToWideChar(CP_UTF8, 0, s.c_str(), -1, out.data(), n);
-  }
-  return out;
-}
-
 }  // namespace
 
 uint32_t ShowNotificationWin(const NotificationOptions& opts,

--- a/backend-common/src/strings_win.cc
+++ b/backend-common/src/strings_win.cc
@@ -1,0 +1,33 @@
+// Copyright 2025 Divy Srivastava. All rights reserved. MIT license.
+
+#include "laufey_backend_common.h"
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+namespace laufey_common {
+
+std::wstring Utf8ToWide(const std::string& s) {
+  if (s.empty())
+    return std::wstring();
+  int n = MultiByteToWideChar(CP_UTF8, 0, s.c_str(), -1, nullptr, 0);
+  if (n <= 0)
+    return std::wstring();
+  std::wstring w(static_cast<size_t>(n - 1), L'\0');
+  MultiByteToWideChar(CP_UTF8, 0, s.c_str(), -1, &w[0], n);
+  return w;
+}
+
+std::string WideToUtf8(const std::wstring& w) {
+  if (w.empty())
+    return std::string();
+  int n = WideCharToMultiByte(CP_UTF8, 0, w.c_str(), -1, nullptr, 0, nullptr,
+                              nullptr);
+  if (n <= 0)
+    return std::string();
+  std::string s(static_cast<size_t>(n - 1), '\0');
+  WideCharToMultiByte(CP_UTF8, 0, w.c_str(), -1, &s[0], n, nullptr, nullptr);
+  return s;
+}
+
+}  // namespace laufey_common

--- a/backend-common/src/tray_win.cc
+++ b/backend-common/src/tray_win.cc
@@ -252,17 +252,6 @@ HICON DecodePngToHicon(const void* bytes, size_t len, int desired) {
   return hicon;
 }
 
-std::wstring Utf8ToWide(const char* s) {
-  if (!s || !*s) return std::wstring();
-  int n = MultiByteToWideChar(CP_UTF8, 0, s, -1, nullptr, 0);
-  std::wstring out;
-  if (n > 0) {
-    out.resize(n - 1);
-    MultiByteToWideChar(CP_UTF8, 0, s, -1, out.data(), n);
-  }
-  return out;
-}
-
 HMENU BuildWinMenuFromValue(laufey_value_t* val, const laufey_backend_api_t* api,
                              std::map<UINT, std::string>& cmd_to_id) {
   if (!val || !api->value_is_list(val)) return nullptr;
@@ -420,7 +409,7 @@ void SetTrayIconDarkWin(uint32_t tray_id, const void* png_bytes, size_t len) {
 void SetTrayTooltipWin(uint32_t tray_id, const char* tooltip_or_null) {
   HWND hwnd = g_tray_msg_hwnd;
   if (!hwnd) return;
-  std::wstring wtip = Utf8ToWide(tooltip_or_null);
+  std::wstring wtip = Utf8ToWide(tooltip_or_null ? tooltip_or_null : "");
   NOTIFYICONDATAW nid = {};
   nid.cbSize = sizeof(nid);
   nid.hWnd = hwnd;

--- a/cef/src/main_windows.cc
+++ b/cef/src/main_windows.cc
@@ -318,8 +318,8 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
   }
 
   wchar_t port_buf[16];
-  DWORD port_len = GetEnvironmentVariableW(L"LAUFEY_REMOTE_DEBUGGING_PORT",
-                                           port_buf, 16);
+  DWORD port_len =
+      GetEnvironmentVariableW(L"LAUFEY_REMOTE_DEBUGGING_PORT", port_buf, 16);
   // On a value of 16+ chars the API returns the required size and leaves the
   // buffer untouched, so the upper bound is load-bearing.
   if (port_len > 0 && port_len < 16) {

--- a/cef/src/main_windows.cc
+++ b/cef/src/main_windows.cc
@@ -5,6 +5,7 @@
 
 #include <iostream>
 #include <string>
+#include <cstdlib>
 #include <cstring>
 
 #include "include/base/cef_callback.h"
@@ -17,15 +18,14 @@
 #include "include/wrapper/cef_helpers.h"
 
 #include "app.h"
+#include "laufey_backend_common.h"
 #include "renderer_app.h"
 #include "runtime_loader.h"
 
 void LaufeyOpenExternalURL(const std::string& url) {
-  int wlen = MultiByteToWideChar(CP_UTF8, 0, url.c_str(), -1, nullptr, 0);
-  if (wlen <= 0)
+  std::wstring wurl = laufey_common::Utf8ToWide(url);
+  if (wurl.empty())
     return;
-  std::wstring wurl(static_cast<size_t>(wlen - 1), L'\0');
-  MultiByteToWideChar(CP_UTF8, 0, url.c_str(), -1, &wurl[0], wlen);
   ShellExecuteW(nullptr, L"open", wurl.c_str(), nullptr, nullptr,
                 SW_SHOWNORMAL);
 }
@@ -208,7 +208,15 @@ class LaufeyCombinedApp : public CefApp, public CefBrowserProcessHandler {
 
     if (!g_runtime_path.empty()) {
       if (!RuntimeLoader::GetInstance()->Load(g_runtime_path)) {
-        std::cerr << "Failed to load runtime, exiting" << std::endl;
+        // WIN32 subsystem: stderr is usually detached, so also show a
+        // dialog (matches the webview binary's load-failure behavior).
+        std::cerr << "Failed to load runtime from: " << g_runtime_path
+                  << std::endl;
+        MessageBoxW(nullptr,
+                    (L"Failed to load runtime from: " +
+                     laufey_common::Utf8ToWide(g_runtime_path))
+                        .c_str(),
+                    L"LAUFEY Error", MB_OK | MB_ICONERROR);
         CefQuitMessageLoop();
         return;
       }
@@ -253,12 +261,9 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
   if (argv) {
     for (int i = 1; i < argc; ++i) {
       if (wcscmp(argv[i], L"--runtime") == 0 && i + 1 < argc) {
-        ++i;
-        int size = WideCharToMultiByte(CP_UTF8, 0, argv[i], -1, nullptr, 0,
-                                       nullptr, nullptr);
-        g_runtime_path.resize(size - 1);
-        WideCharToMultiByte(CP_UTF8, 0, argv[i], -1, &g_runtime_path[0], size,
-                            nullptr, nullptr);
+        g_runtime_path = laufey_common::WideToUtf8(argv[++i]);
+      } else if (wcsncmp(argv[i], L"--runtime=", 10) == 0) {
+        g_runtime_path = laufey_common::WideToUtf8(argv[i] + 10);
       }
     }
   }
@@ -266,15 +271,18 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
   if (g_runtime_path.empty()) {
     // Read as UTF-16 and convert to UTF-8; the ANSI variant would garble
     // non-ASCII paths in the active codepage.
-    wchar_t envPath[MAX_PATH];
-    DWORD envLen =
-        GetEnvironmentVariableW(L"LAUFEY_RUNTIME_PATH", envPath, MAX_PATH);
-    if (envLen > 0 && envLen < MAX_PATH) {
-      int size = WideCharToMultiByte(CP_UTF8, 0, envPath, -1, nullptr, 0,
-                                     nullptr, nullptr);
-      g_runtime_path.resize(size - 1);
-      WideCharToMultiByte(CP_UTF8, 0, envPath, -1, &g_runtime_path[0], size,
-                          nullptr, nullptr);
+    std::wstring envPath(MAX_PATH, L'\0');
+    DWORD envLen = GetEnvironmentVariableW(L"LAUFEY_RUNTIME_PATH", &envPath[0],
+                                           static_cast<DWORD>(envPath.size()));
+    if (envLen >= envPath.size()) {
+      // Buffer too small; envLen is the required size including the NUL.
+      envPath.resize(envLen);
+      envLen = GetEnvironmentVariableW(L"LAUFEY_RUNTIME_PATH", &envPath[0],
+                                       static_cast<DWORD>(envPath.size()));
+    }
+    if (envLen > 0 && envLen < envPath.size()) {
+      envPath.resize(envLen);
+      g_runtime_path = laufey_common::WideToUtf8(envPath);
     }
   }
 
@@ -295,17 +303,27 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
   settings.no_sandbox = true;
   settings.log_severity = LaufeyCefLogSeverity();
 
-  // Set cache path
-  char tempPath[MAX_PATH];
-  GetTempPathA(MAX_PATH, tempPath);
-  std::string cache_path = std::string(tempPath) + "laufey_cef_" +
-                           std::to_string(GetCurrentProcessId());
-  CefString(&settings.root_cache_path) = cache_path;
+  // Set cache path. CefString decodes std::string as UTF-8, so read the
+  // temp dir wide and convert; GetTempPathA would hand over active-codepage
+  // bytes that garble non-ASCII profile names. On failure leave the cache
+  // path unset (CEF then runs with its in-memory default) rather than
+  // pointing it at garbage.
+  wchar_t tempPath[MAX_PATH + 2];
+  DWORD tempLen = GetTempPathW(MAX_PATH + 2, tempPath);
+  if (tempLen > 0 && tempLen < MAX_PATH + 2) {
+    std::string cache_path = laufey_common::WideToUtf8(tempPath) +
+                             "laufey_cef_" +
+                             std::to_string(GetCurrentProcessId());
+    CefString(&settings.root_cache_path) = cache_path;
+  }
 
-  char port_buf[16];
-  if (GetEnvironmentVariableA("LAUFEY_REMOTE_DEBUGGING_PORT", port_buf,
-                              sizeof(port_buf)) > 0) {
-    int port = atoi(port_buf);
+  wchar_t port_buf[16];
+  DWORD port_len = GetEnvironmentVariableW(L"LAUFEY_REMOTE_DEBUGGING_PORT",
+                                           port_buf, 16);
+  // On a value of 16+ chars the API returns the required size and leaves the
+  // buffer untouched, so the upper bound is load-bearing.
+  if (port_len > 0 && port_len < 16) {
+    int port = _wtoi(port_buf);
     if (port > 0 && port < 65536) {
       settings.remote_debugging_port = port;
     }

--- a/cef/src/main_windows.cc
+++ b/cef/src/main_windows.cc
@@ -264,9 +264,17 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
   }
 
   if (g_runtime_path.empty()) {
-    char envPath[MAX_PATH];
-    if (GetEnvironmentVariableA("LAUFEY_RUNTIME_PATH", envPath, MAX_PATH) > 0) {
-      g_runtime_path = envPath;
+    // Read as UTF-16 and convert to UTF-8; the ANSI variant would garble
+    // non-ASCII paths in the active codepage.
+    wchar_t envPath[MAX_PATH];
+    DWORD envLen =
+        GetEnvironmentVariableW(L"LAUFEY_RUNTIME_PATH", envPath, MAX_PATH);
+    if (envLen > 0 && envLen < MAX_PATH) {
+      int size = WideCharToMultiByte(CP_UTF8, 0, envPath, -1, nullptr, 0,
+                                     nullptr, nullptr);
+      g_runtime_path.resize(size - 1);
+      WideCharToMultiByte(CP_UTF8, 0, envPath, -1, &g_runtime_path[0], size,
+                          nullptr, nullptr);
     }
   }
 

--- a/cef/src/runtime_loader.cc
+++ b/cef/src/runtime_loader.cc
@@ -72,9 +72,26 @@ std::string GetExecutablePath() {
 #endif
 }
 
+#if defined(_WIN32)
+// Paths flow through this file as UTF-8 (see GetExecutablePath), so the
+// ANSI (*A) APIs would misread any non-ASCII characters in the active
+// codepage. Convert back to UTF-16 for the wide (*W) APIs.
+std::wstring Utf8ToWidePath(const std::string& s) {
+  if (s.empty())
+    return std::wstring();
+  int n = MultiByteToWideChar(CP_UTF8, 0, s.c_str(), -1, nullptr, 0);
+  if (n <= 0)
+    return std::wstring();
+  std::wstring w(static_cast<size_t>(n - 1), L'\0');
+  MultiByteToWideChar(CP_UTF8, 0, s.c_str(), -1, &w[0], n);
+  return w;
+}
+#endif
+
 bool PathExists(const std::string& path) {
 #if defined(_WIN32)
-  return GetFileAttributesA(path.c_str()) != INVALID_FILE_ATTRIBUTES;
+  return GetFileAttributesW(Utf8ToWidePath(path).c_str()) !=
+         INVALID_FILE_ATTRIBUTES;
 #else
   return access(path.c_str(), F_OK) == 0;
 #endif
@@ -1698,7 +1715,7 @@ bool RuntimeLoader::Load(const std::string& path) {
     return false;
   }
 #else
-  library_handle_ = LoadLibraryA(path.c_str());
+  library_handle_ = LoadLibraryW(Utf8ToWidePath(path).c_str());
   if (!library_handle_) {
     std::cerr << "Failed to load runtime: error " << GetLastError()
               << std::endl;

--- a/cef/src/runtime_loader.cc
+++ b/cef/src/runtime_loader.cc
@@ -72,25 +72,12 @@ std::string GetExecutablePath() {
 #endif
 }
 
-#if defined(_WIN32)
-// Paths flow through this file as UTF-8 (see GetExecutablePath), so the
-// ANSI (*A) APIs would misread any non-ASCII characters in the active
-// codepage. Convert back to UTF-16 for the wide (*W) APIs.
-std::wstring Utf8ToWidePath(const std::string& s) {
-  if (s.empty())
-    return std::wstring();
-  int n = MultiByteToWideChar(CP_UTF8, 0, s.c_str(), -1, nullptr, 0);
-  if (n <= 0)
-    return std::wstring();
-  std::wstring w(static_cast<size_t>(n - 1), L'\0');
-  MultiByteToWideChar(CP_UTF8, 0, s.c_str(), -1, &w[0], n);
-  return w;
-}
-#endif
-
 bool PathExists(const std::string& path) {
 #if defined(_WIN32)
-  return GetFileAttributesW(Utf8ToWidePath(path).c_str()) !=
+  // Paths flow through this file as UTF-8 (see GetExecutablePath), so the
+  // ANSI (*A) APIs would misread any non-ASCII characters in the active
+  // codepage. Convert back to UTF-16 for the wide (*W) APIs.
+  return GetFileAttributesW(laufey_common::Utf8ToWide(path).c_str()) !=
          INVALID_FILE_ATTRIBUTES;
 #else
   return access(path.c_str(), F_OK) == 0;
@@ -1715,7 +1702,7 @@ bool RuntimeLoader::Load(const std::string& path) {
     return false;
   }
 #else
-  library_handle_ = LoadLibraryW(Utf8ToWidePath(path).c_str());
+  library_handle_ = LoadLibraryW(laufey_common::Utf8ToWide(path).c_str());
   if (!library_handle_) {
     std::cerr << "Failed to load runtime: error " << GetLastError()
               << std::endl;

--- a/webview/src/main_windows.cc
+++ b/webview/src/main_windows.cc
@@ -36,9 +36,17 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
   }
 
   if (runtimePath.empty()) {
-    char envPath[MAX_PATH];
-    if (GetEnvironmentVariableA("LAUFEY_RUNTIME_PATH", envPath, MAX_PATH) > 0) {
-      runtimePath = envPath;
+    // Read as UTF-16 and convert to UTF-8; the ANSI variant would garble
+    // non-ASCII paths in the active codepage.
+    wchar_t envPath[MAX_PATH];
+    DWORD envLen =
+        GetEnvironmentVariableW(L"LAUFEY_RUNTIME_PATH", envPath, MAX_PATH);
+    if (envLen > 0 && envLen < MAX_PATH) {
+      int size = WideCharToMultiByte(CP_UTF8, 0, envPath, -1, nullptr, 0,
+                                     nullptr, nullptr);
+      runtimePath.resize(size - 1);
+      WideCharToMultiByte(CP_UTF8, 0, envPath, -1, &runtimePath[0], size,
+                          nullptr, nullptr);
     }
   }
 
@@ -73,9 +81,16 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
   loader->SetBackend(backend);
 
   if (!loader->Load(runtimePath)) {
-    MessageBoxA(nullptr,
-                ("Failed to load runtime from: " + runtimePath).c_str(),
-                "LAUFEY Webview Error", MB_OK | MB_ICONERROR);
+    // The path is UTF-8; show it through the wide API so non-ASCII
+    // characters render correctly in the dialog.
+    int wlen =
+        MultiByteToWideChar(CP_UTF8, 0, runtimePath.c_str(), -1, nullptr, 0);
+    std::wstring wpath(wlen > 0 ? wlen - 1 : 0, L'\0');
+    if (wlen > 0) {
+      MultiByteToWideChar(CP_UTF8, 0, runtimePath.c_str(), -1, &wpath[0], wlen);
+    }
+    MessageBoxW(nullptr, (L"Failed to load runtime from: " + wpath).c_str(),
+                L"LAUFEY Webview Error", MB_OK | MB_ICONERROR);
     delete backend;
     CoUninitialize();
     return 1;

--- a/webview/src/main_windows.cc
+++ b/webview/src/main_windows.cc
@@ -1,5 +1,6 @@
 // Copyright 2025 Divy Srivastava. All rights reserved. MIT license.
 
+#include "laufey_backend_common.h"
 #include "runtime_loader.h"
 
 #define WIN32_LEAN_AND_MEAN
@@ -24,12 +25,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
   if (argv) {
     for (int i = 1; i < argc; ++i) {
       if (wcscmp(argv[i], L"--runtime") == 0 && i + 1 < argc) {
-        ++i;
-        int size = WideCharToMultiByte(CP_UTF8, 0, argv[i], -1, nullptr, 0,
-                                       nullptr, nullptr);
-        runtimePath.resize(size - 1);
-        WideCharToMultiByte(CP_UTF8, 0, argv[i], -1, &runtimePath[0], size,
-                            nullptr, nullptr);
+        runtimePath = laufey_common::WideToUtf8(argv[++i]);
       }
     }
     LocalFree(argv);
@@ -38,15 +34,18 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
   if (runtimePath.empty()) {
     // Read as UTF-16 and convert to UTF-8; the ANSI variant would garble
     // non-ASCII paths in the active codepage.
-    wchar_t envPath[MAX_PATH];
-    DWORD envLen =
-        GetEnvironmentVariableW(L"LAUFEY_RUNTIME_PATH", envPath, MAX_PATH);
-    if (envLen > 0 && envLen < MAX_PATH) {
-      int size = WideCharToMultiByte(CP_UTF8, 0, envPath, -1, nullptr, 0,
-                                     nullptr, nullptr);
-      runtimePath.resize(size - 1);
-      WideCharToMultiByte(CP_UTF8, 0, envPath, -1, &runtimePath[0], size,
-                          nullptr, nullptr);
+    std::wstring envPath(MAX_PATH, L'\0');
+    DWORD envLen = GetEnvironmentVariableW(L"LAUFEY_RUNTIME_PATH", &envPath[0],
+                                           static_cast<DWORD>(envPath.size()));
+    if (envLen >= envPath.size()) {
+      // Buffer too small; envLen is the required size including the NUL.
+      envPath.resize(envLen);
+      envLen = GetEnvironmentVariableW(L"LAUFEY_RUNTIME_PATH", &envPath[0],
+                                       static_cast<DWORD>(envPath.size()));
+    }
+    if (envLen > 0 && envLen < envPath.size()) {
+      envPath.resize(envLen);
+      runtimePath = laufey_common::WideToUtf8(envPath);
     }
   }
 
@@ -55,22 +54,22 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
   }
 
   if (runtimePath.empty()) {
-    const char* searchPaths[] = {".\\runtime.dll",
-                                 ".\\target\\debug\\hello.dll",
-                                 ".\\target\\release\\hello.dll"};
-    for (const char* path : searchPaths) {
-      if (GetFileAttributesA(path) != INVALID_FILE_ATTRIBUTES) {
-        runtimePath = path;
+    const wchar_t* searchPaths[] = {L".\\runtime.dll",
+                                    L".\\target\\debug\\hello.dll",
+                                    L".\\target\\release\\hello.dll"};
+    for (const wchar_t* path : searchPaths) {
+      if (GetFileAttributesW(path) != INVALID_FILE_ATTRIBUTES) {
+        runtimePath = laufey_common::WideToUtf8(path);
         break;
       }
     }
   }
 
   if (runtimePath.empty()) {
-    MessageBoxA(nullptr,
-                "No runtime library found.\nSet LAUFEY_RUNTIME_PATH or use "
-                "--runtime <path>",
-                "LAUFEY Webview Error", MB_OK | MB_ICONERROR);
+    MessageBoxW(nullptr,
+                L"No runtime library found.\nSet LAUFEY_RUNTIME_PATH or use "
+                L"--runtime <path>",
+                L"LAUFEY Webview Error", MB_OK | MB_ICONERROR);
     CoUninitialize();
     return 1;
   }
@@ -83,13 +82,10 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
   if (!loader->Load(runtimePath)) {
     // The path is UTF-8; show it through the wide API so non-ASCII
     // characters render correctly in the dialog.
-    int wlen =
-        MultiByteToWideChar(CP_UTF8, 0, runtimePath.c_str(), -1, nullptr, 0);
-    std::wstring wpath(wlen > 0 ? wlen - 1 : 0, L'\0');
-    if (wlen > 0) {
-      MultiByteToWideChar(CP_UTF8, 0, runtimePath.c_str(), -1, &wpath[0], wlen);
-    }
-    MessageBoxW(nullptr, (L"Failed to load runtime from: " + wpath).c_str(),
+    MessageBoxW(nullptr,
+                (L"Failed to load runtime from: " +
+                 laufey_common::Utf8ToWide(runtimePath))
+                    .c_str(),
                 L"LAUFEY Webview Error", MB_OK | MB_ICONERROR);
     delete backend;
     CoUninitialize();
@@ -97,7 +93,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
   }
 
   if (!loader->Start()) {
-    MessageBoxA(nullptr, "Failed to start runtime", "LAUFEY Webview Error",
+    MessageBoxW(nullptr, L"Failed to start runtime", L"LAUFEY Webview Error",
                 MB_OK | MB_ICONERROR);
     delete backend;
     CoUninitialize();

--- a/webview/src/runtime_loader.cc
+++ b/webview/src/runtime_loader.cc
@@ -64,25 +64,12 @@ std::string GetExecutablePath() {
 #endif
 }
 
-#if defined(_WIN32)
-// Paths flow through this file as UTF-8 (see GetExecutablePath), so the
-// ANSI (*A) APIs would misread any non-ASCII characters in the active
-// codepage. Convert back to UTF-16 for the wide (*W) APIs.
-std::wstring Utf8ToWidePath(const std::string& s) {
-  if (s.empty())
-    return std::wstring();
-  int n = MultiByteToWideChar(CP_UTF8, 0, s.c_str(), -1, nullptr, 0);
-  if (n <= 0)
-    return std::wstring();
-  std::wstring w(static_cast<size_t>(n - 1), L'\0');
-  MultiByteToWideChar(CP_UTF8, 0, s.c_str(), -1, &w[0], n);
-  return w;
-}
-#endif
-
 bool PathExists(const std::string& path) {
 #if defined(_WIN32)
-  return GetFileAttributesW(Utf8ToWidePath(path).c_str()) !=
+  // Paths flow through this file as UTF-8 (see GetExecutablePath), so the
+  // ANSI (*A) APIs would misread any non-ASCII characters in the active
+  // codepage. Convert back to UTF-16 for the wide (*W) APIs.
+  return GetFileAttributesW(laufey_common::Utf8ToWide(path).c_str()) !=
          INVALID_FILE_ATTRIBUTES;
 #else
   return access(path.c_str(), F_OK) == 0;
@@ -858,7 +845,7 @@ bool RuntimeLoader::Load(const std::string& path) {
     return false;
   }
 #else
-  library_handle_ = LoadLibraryW(Utf8ToWidePath(path).c_str());
+  library_handle_ = LoadLibraryW(laufey_common::Utf8ToWide(path).c_str());
   if (!library_handle_) {
     std::cerr << "Failed to load runtime: " << GetLastError() << std::endl;
     return false;

--- a/webview/src/runtime_loader.cc
+++ b/webview/src/runtime_loader.cc
@@ -64,9 +64,26 @@ std::string GetExecutablePath() {
 #endif
 }
 
+#if defined(_WIN32)
+// Paths flow through this file as UTF-8 (see GetExecutablePath), so the
+// ANSI (*A) APIs would misread any non-ASCII characters in the active
+// codepage. Convert back to UTF-16 for the wide (*W) APIs.
+std::wstring Utf8ToWidePath(const std::string& s) {
+  if (s.empty())
+    return std::wstring();
+  int n = MultiByteToWideChar(CP_UTF8, 0, s.c_str(), -1, nullptr, 0);
+  if (n <= 0)
+    return std::wstring();
+  std::wstring w(static_cast<size_t>(n - 1), L'\0');
+  MultiByteToWideChar(CP_UTF8, 0, s.c_str(), -1, &w[0], n);
+  return w;
+}
+#endif
+
 bool PathExists(const std::string& path) {
 #if defined(_WIN32)
-  return GetFileAttributesA(path.c_str()) != INVALID_FILE_ATTRIBUTES;
+  return GetFileAttributesW(Utf8ToWidePath(path).c_str()) !=
+         INVALID_FILE_ATTRIBUTES;
 #else
   return access(path.c_str(), F_OK) == 0;
 #endif
@@ -841,7 +858,7 @@ bool RuntimeLoader::Load(const std::string& path) {
     return false;
   }
 #else
-  library_handle_ = LoadLibraryA(path.c_str());
+  library_handle_ = LoadLibraryW(Utf8ToWidePath(path).c_str());
   if (!library_handle_) {
     std::cerr << "Failed to load runtime: " << GetLastError() << std::endl;
     return false;

--- a/webview/src/webview_windows.cc
+++ b/webview/src/webview_windows.cc
@@ -67,27 +67,8 @@ inline uint32_t GetLaufeyModifiers() {
 
 }  // namespace keyboard
 
-// Convert UTF-8 to wide string
-static std::wstring Utf8ToWide(const std::string& str) {
-  if (str.empty())
-    return std::wstring();
-  int size = MultiByteToWideChar(CP_UTF8, 0, str.c_str(), -1, nullptr, 0);
-  std::wstring result(size - 1, 0);
-  MultiByteToWideChar(CP_UTF8, 0, str.c_str(), -1, &result[0], size);
-  return result;
-}
-
-// Convert wide string to UTF-8
-static std::string WideToUtf8(const std::wstring& wstr) {
-  if (wstr.empty())
-    return std::string();
-  int size = WideCharToMultiByte(CP_UTF8, 0, wstr.c_str(), -1, nullptr, 0,
-                                 nullptr, nullptr);
-  std::string result(size - 1, 0);
-  WideCharToMultiByte(CP_UTF8, 0, wstr.c_str(), -1, &result[0], size, nullptr,
-                      nullptr);
-  return result;
-}
+using laufey_common::Utf8ToWide;
+using laufey_common::WideToUtf8;
 
 // HWND → laufey_id mapping
 static std::map<HWND, uint32_t> g_hwnd_to_laufey_id;


### PR DESCRIPTION
## Summary

On Windows, a packaged app fails to launch when its directory path (or the
exe/dll base name) contains any non-ASCII characters — e.g. a Japanese user
profile like `C:\Users\山田\Desktop\MyApp`. The launcher shows:

```
LAUFEY Webview Error
No runtime library found.
Set LAUFEY_RUNTIME_PATH or use --runtime <path>
```

and even an explicit `--runtime <path>` fails with a mojibake'd path:

```
Failed to load runtime from: ...\dist\譌･譛ｬ隱槭ヵ繧ｩ繝ｫ繝\HelloRepro.dll
```

Reported downstream with a minimal repro as denoland/deno#36591.

## Root cause

Paths flow through the launchers as UTF-8 (`GetModuleFileNameW` /
`CommandLineToArgvW` → `WideCharToMultiByte(CP_UTF8, ...)`), but were then
handed to *ANSI* Win32 APIs, which reinterpret the bytes in the active
codepage (CP932 on ja-JP systems):

- `PathExists` → `GetFileAttributesA` (webview + cef `runtime_loader.cc`),
  so `LaufeyFindColocatedRuntime()` never finds the colocated `<App>.dll`
- `RuntimeLoader::Load` → `LoadLibraryA` (webview + cef), so even a
  correctly-obtained path fails to load
- `GetEnvironmentVariableA("LAUFEY_RUNTIME_PATH", ...)` (webview + cef
  `main_windows.cc`), so the documented workaround can't express non-ASCII
  paths either

## Changes

- Add a local `Utf8ToWidePath` helper (following the per-TU `Utf8ToWide`
  convention used in backend-common) to both `runtime_loader.cc` files and
  route `PathExists` / `Load` through `GetFileAttributesW` / `LoadLibraryW`.
- Read `LAUFEY_RUNTIME_PATH` with `GetEnvironmentVariableW` and convert to
  UTF-8, in both `main_windows.cc` files.
- webview `main_windows.cc`: show the "Failed to load runtime from" dialog
  via `MessageBoxW` so the embedded path renders correctly.

Deliberately untouched: `GetEnvironmentVariableA` reads of
`NODE_CHANNEL_FD` / `NEXT_PRIVATE_WORKER` / `LAUFEY_REMOTE_DEBUGGING_PORT`
(ASCII-only values), and the ASCII-literal dev fallback paths
(`.\runtime.dll` etc.).

## Testing

On Windows 11 x64, system locale ja-JP (ACP 932), with a `deno desktop`
(2.9.5) bundle:

1. Built `laufey_webview.exe` from this branch (MSVC 2022, WebView2 SDK).
2. Renamed it to `HelloRepro.exe` next to the deno-compiled `HelloRepro.dll`
   inside a folder named `日本語フォルダ`, with the dll also renamed to a
   Japanese name.
3. Before this change: "No runtime library found" (and with `--runtime`:
   "Failed to load runtime from" with a CP932-garbled path).
   After: the app launches and the window opens normally, both via colocated
   detection and via `--runtime` / `LAUFEY_RUNTIME_PATH` with Japanese paths.
4. ASCII-path launch still works (no regression).

The CEF backend change is the same mechanical pattern; I could not build the
CEF dist locally, so it is compile-reviewed only — happy to adjust if CI
flags anything.
