### PR TITLE
feat: add click passthrough backend API

### DIFF
--- a/backend-winit-common/src/lib.rs
+++ b/backend-winit-common/src/lib.rs
@@ -33,7 +33,7 @@ use winit::window::{Window, WindowLevel};
 // Bumping this in lockstep with the capi is mandatory: the capi's `init_api`
 // rejects any backend whose reported `version` differs, and the vtable layout
 // below must match the `laufey_backend_api` struct as of this version.
-pub const LAUFEY_API_VERSION: u32 = 32;
+pub const LAUFEY_API_VERSION: u32 = 33;
 
 /// Creation-time window style flags (mirror `LAUFEY_WINDOW_FLAG_*` in laufey.h).
 pub const LAUFEY_WINDOW_FLAG_FRAMELESS: u32 = 1 << 0;
@@ -547,6 +547,13 @@ pub struct LaufeyBackendApi {
       *mut c_void,
     ),
   >,
+
+  // --- Click passthrough (API >= 33) ---
+  // Implemented via winit's `Window::set_cursor_hittest`.
+  pub set_click_passthrough:
+    Option<unsafe extern "C" fn(*mut c_void, u32, bool)>,
+  pub is_click_passthrough:
+    Option<unsafe extern "C" fn(*mut c_void, u32) -> bool>,
 }
 
 unsafe impl Send for LaufeyBackendApi {}
@@ -1182,6 +1189,9 @@ pub fn create_api_base() -> LaufeyBackendApi {
     test_trigger_close_requested: None,
     // Print to PDF (API >= 32): winit renders no web content.
     print_to_pdf: None,
+    // Click passthrough (API >= 33): filled by fill_common_api.
+    set_click_passthrough: None,
+    is_click_passthrough: None,
   }
 }
 
@@ -1713,6 +1723,7 @@ pub struct WindowState {
   pub pending_position: Mutex<Option<(i32, i32)>>,
   pub pending_resizable: Mutex<Option<bool>>,
   pub pending_always_on_top: Mutex<Option<bool>>,
+  pub pending_click_passthrough: Mutex<Option<bool>>,
   pub pending_visible: Mutex<Option<bool>>,
   /// Creation-time style flags (LAUFEY_WINDOW_FLAG_*) for frameless /
   /// non-activating panel windows; applied when the winit Window is built.
@@ -1734,6 +1745,7 @@ impl WindowState {
       pending_position: Mutex::new(None),
       pending_resizable: Mutex::new(None),
       pending_always_on_top: Mutex::new(None),
+      pending_click_passthrough: Mutex::new(None),
       pending_visible: Mutex::new(None),
       pending_flags: Mutex::new(0),
       pending_app_menu: Mutex::new(None),
@@ -1852,6 +1864,9 @@ pub enum CommonEvent {
     window_id: u32,
   },
   SetAlwaysOnTop {
+    window_id: u32,
+  },
+  SetClickPassthrough {
     window_id: u32,
   },
   Show {
@@ -2141,6 +2156,38 @@ macro_rules! define_common_backend_fns {
           s.common()
             .with_window(window_id, |ws| {
               *ws.pending_always_on_top.lock().unwrap()
+            })
+            .flatten()
+        })
+        .unwrap_or(false)
+    }
+
+    unsafe extern "C" fn backend_set_click_passthrough(
+      _data: *mut ::std::ffi::c_void,
+      window_id: u32,
+      enabled: bool,
+    ) {
+      if let Some(state) = <$B as $crate::BackendAccess>::get() {
+        state.common().with_window(window_id, |ws| {
+          *ws.pending_click_passthrough.lock().unwrap() = Some(enabled);
+        });
+        let _ = state.proxy().send_event(
+          <$B as $crate::BackendAccess>::common_event(
+            $crate::CommonEvent::SetClickPassthrough { window_id },
+          ),
+        );
+      }
+    }
+
+    unsafe extern "C" fn backend_is_click_passthrough(
+      _data: *mut ::std::ffi::c_void,
+      window_id: u32,
+    ) -> bool {
+      <$B as $crate::BackendAccess>::get()
+        .and_then(|s| {
+          s.common()
+            .with_window(window_id, |ws| {
+              *ws.pending_click_passthrough.lock().unwrap()
             })
             .flatten()
         })
@@ -2850,6 +2897,8 @@ macro_rules! fill_common_api {
     $api.is_resizable = Some(backend_is_resizable);
     $api.set_always_on_top = Some(backend_set_always_on_top);
     $api.is_always_on_top = Some(backend_is_always_on_top);
+    $api.set_click_passthrough = Some(backend_set_click_passthrough);
+    $api.is_click_passthrough = Some(backend_is_click_passthrough);
     $api.is_visible = Some(backend_is_visible);
     $api.show = Some(backend_show);
     $api.hide = Some(backend_hide);
@@ -2960,6 +3009,22 @@ pub fn handle_common_event<B: BackendAccess>(
             } else {
               WindowLevel::Normal
             });
+          }
+        });
+      }
+      true
+    }
+    CommonEvent::SetClickPassthrough { window_id: eid, .. }
+      if *eid == window_id =>
+    {
+      if let Some(state) = B::get() {
+        state.common().with_window(window_id, |ws| {
+          if let Some(passthrough) =
+            *ws.pending_click_passthrough.lock().unwrap()
+          {
+            // Hittest off == the cursor falls through to the window below.
+            // Not supported on every platform/session; ignore failures.
+            let _ = window.set_cursor_hittest(!passthrough);
           }
         });
       }
@@ -3136,6 +3201,9 @@ pub fn apply_pending_post_create(ws: &WindowState, window: &Window) {
 
   if let Some(true) = *ws.pending_always_on_top.lock().unwrap() {
     window.set_window_level(WindowLevel::AlwaysOnTop);
+  }
+  if let Some(true) = *ws.pending_click_passthrough.lock().unwrap() {
+    let _ = window.set_cursor_hittest(false);
   }
   // A non-activating panel floats above normal windows, like a tray popover
   // (matches the NSPanel / always-on-top behavior of the other backends).

--- a/capi/include/laufey.h
+++ b/capi/include/laufey.h
@@ -11,7 +11,7 @@
 extern "C" {
 #endif
 
-#define LAUFEY_API_VERSION 32
+#define LAUFEY_API_VERSION 33
 
 // Window handle types for get_window_handle_type
 #define LAUFEY_WINDOW_HANDLE_UNKNOWN 0
@@ -791,6 +791,26 @@ struct laufey_backend_api {
   // version 32; callers must null-check.
   void (*print_to_pdf)(void* backend_data, uint32_t window_id,
                        laufey_pdf_result_fn callback, void* callback_data);
+
+  // --- Click passthrough (API >= 33) -----------------------------------------
+  //
+  // When enabled the window ignores ALL mouse input — clicks, moves, wheel —
+  // and every event falls through to whatever window is beneath it, like
+  // Electron's setIgnoreMouseEvents(true). Keyboard input is unaffected.
+  // Intended for frameless/transparent overlay windows (HUDs, notification
+  // toasts, screen annotations). A live setter that can be toggled at any
+  // time. macOS: NSWindow.ignoresMouseEvents. Windows: WS_EX_TRANSPARENT |
+  // WS_EX_LAYERED on the top-level window. Linux: an empty input shape region
+  // (best-effort under a reparenting X11 window manager — pair it with a
+  // frameless window). NULL on backends older than API version 33; callers
+  // must null-check.
+  void (*set_click_passthrough)(void* backend_data, uint32_t window_id,
+                                bool enabled);
+
+  // Return whether click passthrough is currently enabled for the window.
+  // Returns false if the id is unknown or the backend can't report it. NULL
+  // on backends older than API version 33.
+  bool (*is_click_passthrough)(void* backend_data, uint32_t window_id);
 };
 
 #ifdef __cplusplus

--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -29,7 +29,7 @@ pub use mouse::*;
 /// (`github.com/denoland/laufey/releases/tag/v{VERSION}`).
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-pub const LAUFEY_API_VERSION: u32 = 32;
+pub const LAUFEY_API_VERSION: u32 = 33;
 
 /// Creation-time window style flags for [`Window::new_with_options`].
 /// Mirror the `LAUFEY_WINDOW_FLAG_*` constants in `laufey.h`.
@@ -922,6 +922,37 @@ impl Window {
       unsafe { f(api.backend_data, self.id) }
     } else {
       1.0
+    }
+  }
+
+  /// Builder form of [`Window::set_click_passthrough`].
+  pub fn click_passthrough(self, passthrough: bool) -> Self {
+    self.set_click_passthrough(passthrough);
+    self
+  }
+
+  /// Enable or disable click passthrough. While enabled the window ignores
+  /// all mouse input — clicks, moves, wheel — and every event falls through
+  /// to whatever window is beneath it, like Electron's
+  /// `setIgnoreMouseEvents(true)`. Keyboard input is unaffected. Intended for
+  /// frameless/transparent overlay windows (HUDs, notification toasts, screen
+  /// annotations); can be toggled at any time. No-op on backends without
+  /// passthrough support.
+  pub fn set_click_passthrough(&self, passthrough: bool) {
+    let api = api();
+    if let Some(f) = api.set_click_passthrough {
+      unsafe { f(api.backend_data, self.id, passthrough) };
+    }
+  }
+
+  /// Get whether click passthrough is currently enabled. Returns `false`
+  /// when the backend does not report it.
+  pub fn get_click_passthrough(&self) -> bool {
+    let api = api();
+    if let Some(f) = api.is_click_passthrough {
+      unsafe { f(api.backend_data, self.id) }
+    } else {
+      false
     }
   }
 

--- a/cef/src/main_linux.cc
+++ b/cef/src/main_linux.cc
@@ -6,6 +6,7 @@
 #include <cstdlib>
 #include <unistd.h>
 #include <map>
+#include <set>
 
 #include "include/cef_app.h"
 #include "include/base/cef_callback.h"
@@ -520,6 +521,42 @@ double GetLinuxWindowOpacity(unsigned long xid) {
 #else
   return 1.0;
 #endif
+}
+
+// X11 has no cheap query for "is the input shape empty", so remember which
+// windows we made click-passthrough. Only touched on the CEF UI thread.
+static std::set<unsigned long> g_click_passthrough_xids;
+
+void SetLinuxWindowClickPassthrough(unsigned long xid, bool enabled) {
+#ifdef GDK_WINDOWING_X11
+  GdkDisplay* gdk_display = gdk_display_get_default();
+  if (!gdk_display || !GDK_IS_X11_DISPLAY(gdk_display))
+    return;
+  // Wrap the foreign XID in a GdkWindow so GDK's own XShape linkage sets the
+  // input region — no direct libXext dependency needed.
+  GdkWindow* gdk_win = gdk_x11_window_foreign_new_for_display(gdk_display, xid);
+  if (!gdk_win)
+    return;
+  if (enabled) {
+    // An empty input shape makes the whole window transparent to pointer
+    // events; they fall through to whatever is beneath. Best-effort under a
+    // reparenting window manager (the WM frame may still catch clicks), so
+    // pair it with a frameless window.
+    cairo_region_t* empty = cairo_region_create();
+    gdk_window_input_shape_combine_region(gdk_win, empty, 0, 0);
+    cairo_region_destroy(empty);
+    g_click_passthrough_xids.insert(xid);
+  } else {
+    // NULL restores the default input shape (the full window).
+    gdk_window_input_shape_combine_region(gdk_win, nullptr, 0, 0);
+    g_click_passthrough_xids.erase(xid);
+  }
+  g_object_unref(gdk_win);
+#endif
+}
+
+bool IsLinuxWindowClickPassthrough(unsigned long xid) {
+  return g_click_passthrough_xids.count(xid) != 0;
 }
 
 void MonitorLinuxWindowEvents(unsigned long xid) {

--- a/cef/src/runtime_loader.cc
+++ b/cef/src/runtime_loader.cc
@@ -446,10 +446,17 @@ static void Backend_SetWindowOpacity(void* data, uint32_t window_id,
                       LONG ex = GetWindowLong(hwnd, GWL_EXSTYLE);
                       if (o >= 1.0) {
                         if (ex & WS_EX_LAYERED) {
-                          SetWindowLong(hwnd, GWL_EXSTYLE, ex & ~WS_EX_LAYERED);
-                          RedrawWindow(hwnd, nullptr, nullptr,
-                                       RDW_ERASE | RDW_INVALIDATE | RDW_FRAME |
-                                           RDW_ALLCHILDREN);
+                          if (ex & WS_EX_TRANSPARENT) {
+                            // Click passthrough needs the layered style;
+                            // keep it and just reset the alpha.
+                            SetLayeredWindowAttributes(hwnd, 0, 255, LWA_ALPHA);
+                          } else {
+                            SetWindowLong(hwnd, GWL_EXSTYLE,
+                                          ex & ~WS_EX_LAYERED);
+                            RedrawWindow(hwnd, nullptr, nullptr,
+                                         RDW_ERASE | RDW_INVALIDATE |
+                                             RDW_FRAME | RDW_ALLCHILDREN);
+                          }
                         }
                       } else {
                         if (!(ex & WS_EX_LAYERED))
@@ -493,6 +500,93 @@ static double Backend_GetWindowOpacity(void* data, uint32_t window_id) {
       result = GetNSWindowOpacity(window->GetWindowHandle());
 #elif defined(__linux__)
       result = GetLinuxWindowOpacity(window->GetWindowHandle());
+#endif
+    });
+  }
+  return result;
+}
+
+static void Backend_SetClickPassthrough(void* data, uint32_t window_id,
+                                        bool enabled) {
+  RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);
+  CefRefPtr<CefBrowser> browser = loader->GetBrowserForWindow(window_id);
+  if (browser) {
+    CefPostTask(
+        TID_UI,
+        base::BindOnce(
+            [](CefRefPtr<CefBrowser> b, bool en) {
+              auto browser_view = CefBrowserView::GetForBrowser(b);
+              if (!browser_view)
+                return;
+              auto window = browser_view->GetWindow();
+              if (!window)
+                return;
+#ifdef _WIN32
+              HWND hwnd = window->GetWindowHandle();
+              LONG ex = GetWindowLong(hwnd, GWL_EXSTYLE);
+              if (en) {
+                // WS_EX_TRANSPARENT excludes the whole top-level window
+                // (children included, so also CEF's widget windows) from
+                // mouse hit-testing, but only on a layered window.
+                bool newly_layered = !(ex & WS_EX_LAYERED);
+                SetWindowLong(hwnd, GWL_EXSTYLE,
+                              ex | WS_EX_TRANSPARENT | WS_EX_LAYERED);
+                if (newly_layered) {
+                  // A window that just became layered renders nothing until
+                  // its transparency attributes are set; fully opaque keeps
+                  // it visually unchanged.
+                  SetLayeredWindowAttributes(hwnd, 0, 255, LWA_ALPHA);
+                }
+              } else {
+                LONG new_ex = ex & ~WS_EX_TRANSPARENT;
+                // Drop the layered style too unless a window opacity < 1.0
+                // still needs it.
+                BYTE alpha = 255;
+                DWORD flags = 0;
+                bool has_alpha =
+                    (ex & WS_EX_LAYERED) &&
+                    GetLayeredWindowAttributes(hwnd, nullptr, &alpha, &flags) &&
+                    (flags & LWA_ALPHA) && alpha < 255;
+                if (!has_alpha)
+                  new_ex &= ~WS_EX_LAYERED;
+                if (new_ex != ex) {
+                  SetWindowLong(hwnd, GWL_EXSTYLE, new_ex);
+                  if ((ex & WS_EX_LAYERED) && !(new_ex & WS_EX_LAYERED)) {
+                    RedrawWindow(hwnd, nullptr, nullptr,
+                                 RDW_ERASE | RDW_INVALIDATE | RDW_FRAME |
+                                     RDW_ALLCHILDREN);
+                  }
+                }
+              }
+#elif defined(__APPLE__)
+              SetNSWindowClickPassthrough(window->GetWindowHandle(), en);
+#elif defined(__linux__)
+              SetLinuxWindowClickPassthrough(window->GetWindowHandle(), en);
+#endif
+            },
+            browser, enabled));
+  }
+}
+
+static bool Backend_IsClickPassthrough(void* data, uint32_t window_id) {
+  RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);
+  CefRefPtr<CefBrowser> browser = loader->GetBrowserForWindow(window_id);
+  bool result = false;
+  if (browser) {
+    cef_invoke_sync([&] {
+      auto browser_view = CefBrowserView::GetForBrowser(browser);
+      if (!browser_view)
+        return;
+      auto window = browser_view->GetWindow();
+      if (!window)
+        return;
+#ifdef _WIN32
+      HWND hwnd = window->GetWindowHandle();
+      result = (GetWindowLong(hwnd, GWL_EXSTYLE) & WS_EX_TRANSPARENT) != 0;
+#elif defined(__APPLE__)
+      result = IsNSWindowClickPassthrough(window->GetWindowHandle());
+#elif defined(__linux__)
+      result = IsLinuxWindowClickPassthrough(window->GetWindowHandle());
 #endif
     });
   }
@@ -1649,6 +1743,8 @@ void RuntimeLoader::InitializeBackendApi() {
   backend_api_.is_always_on_top = Backend_IsAlwaysOnTop;
   backend_api_.set_window_opacity = Backend_SetWindowOpacity;
   backend_api_.get_window_opacity = Backend_GetWindowOpacity;
+  backend_api_.set_click_passthrough = Backend_SetClickPassthrough;
+  backend_api_.is_click_passthrough = Backend_IsClickPassthrough;
   backend_api_.is_visible = Backend_IsVisible;
   backend_api_.show = Backend_Show;
   backend_api_.hide = Backend_Hide;

--- a/cef/src/runtime_loader.h
+++ b/cef/src/runtime_loader.h
@@ -511,6 +511,10 @@ bool IsNSWindowResizable(void* cef_handle);
 // Overall window opacity in [0.0, 1.0] via NSWindow.alphaValue.
 void SetNSWindowOpacity(void* cef_handle, double opacity);
 double GetNSWindowOpacity(void* cef_handle);
+// Click passthrough via NSWindow.ignoresMouseEvents: while enabled all mouse
+// input falls through to whatever is beneath the window.
+void SetNSWindowClickPassthrough(void* cef_handle, bool enabled);
+bool IsNSWindowClickPassthrough(void* cef_handle);
 // Reconfigure the window backing a CEF handle to behave as a floating,
 // non-activating utility panel (used for tray popovers): floats above
 // normal windows, joins all spaces, and doesn't steal focus from the
@@ -540,6 +544,12 @@ bool IsLinuxWindowResizable(unsigned long xid);
 // (honored by compositing window managers). Implemented in main_linux.cc.
 void SetLinuxWindowOpacity(unsigned long xid, double opacity);
 double GetLinuxWindowOpacity(unsigned long xid);
+// Click passthrough via an empty X11 input shape region: while enabled all
+// mouse input falls through to whatever is beneath the window. Best-effort
+// under a reparenting window manager (the WM frame may still catch clicks),
+// so pair it with a frameless window. Implemented in main_linux.cc.
+void SetLinuxWindowClickPassthrough(unsigned long xid, bool enabled);
+bool IsLinuxWindowClickPassthrough(unsigned long xid);
 // Mark the X11 window as a utility/panel window (_NET_WM_WINDOW_TYPE_UTILITY,
 // skip taskbar/pager) so the WM treats it as an auxiliary panel that doesn't
 // take part in normal focus/taskbar handling. Implemented in main_linux.cc.

--- a/cef/src/runtime_loader_mac.mm
+++ b/cef/src/runtime_loader_mac.mm
@@ -61,6 +61,23 @@ double GetNSWindowOpacity(void* cef_handle) {
   return 1.0;
 }
 
+void SetNSWindowClickPassthrough(void* cef_handle, bool enabled) {
+  NSView* view = (__bridge NSView*)cef_handle;
+  NSWindow* nswindow = [view window];
+  if (nswindow) {
+    [nswindow setIgnoresMouseEvents:enabled];
+  }
+}
+
+bool IsNSWindowClickPassthrough(void* cef_handle) {
+  NSView* view = (__bridge NSView*)cef_handle;
+  NSWindow* nswindow = [view window];
+  if (nswindow) {
+    return [nswindow ignoresMouseEvents];
+  }
+  return false;
+}
+
 void ConfigureNSWindowAsPanelForCefHandle(void* cef_handle) {
   NSView* view = (__bridge NSView*)cef_handle;
   NSWindow* nswindow = [view window];

--- a/docs/window-management.md
+++ b/docs/window-management.md
@@ -2,9 +2,9 @@
 
 Every laufey application is built around one or more native windows. A `Window`
 controls its title, size, position, resizable and always-on-top flags, opacity,
-visibility, and focus. The type is a builder, so you can configure a window
-fluently when you create it, and each property also has a plain setter you can
-call later while the window is open.
+click passthrough, visibility, and focus. The type is a builder, so you can
+configure a window fluently when you create it, and each property also has a
+plain setter you can call later while the window is open.
 
 ```rust
 use laufey::Window;
@@ -70,3 +70,42 @@ These are two distinct things:
   (WebKitGTK, on a compositing window manager), and by the Winit backend. It is
   not supported by the Windows WebView2 backend or the CEF backend, which paint
   an opaque window background; the flag is ignored there.
+
+## Click passthrough
+
+`Window::click_passthrough` / `set_click_passthrough` / `get_click_passthrough`
+makes the window ignore _all_ mouse input — clicks, moves, and wheel events fall
+through to whatever window is beneath it, like Electron's
+`setIgnoreMouseEvents(true)`. Keyboard input is unaffected. It is a live setter
+you can toggle at any time, intended for frameless/transparent overlay windows:
+HUDs, notification toasts, screen annotations.
+
+```rust
+use laufey::{Window, WindowOptions};
+
+let overlay = Window::new_with_options(
+  400,
+  300,
+  WindowOptions { frameless: true, transparent: true, ..Default::default() },
+)
+.always_on_top(true)
+.click_passthrough(true)
+.load("overlay.html");
+
+// Later, to start accepting input again:
+overlay.set_click_passthrough(false);
+```
+
+Platform notes:
+
+- **macOS** — `NSWindow.ignoresMouseEvents`; works with every backend.
+- **Windows** — the top-level window gets the `WS_EX_TRANSPARENT` and
+  `WS_EX_LAYERED` extended styles, which exclude it (children included) from
+  mouse hit-testing. Composes with `set_opacity`, which shares the layered
+  style.
+- **Linux** — the window's X11/Wayland input shape region is cleared.
+  Best-effort under a reparenting X11 window manager, where the WM's frame may
+  still catch clicks — pair it with a frameless window (the intended overlay use
+  case) for reliable behavior.
+- The Winit backend uses winit's `set_cursor_hittest`, with the same platform
+  behavior as above.

--- a/examples/native_e2e/src/lib.rs
+++ b/examples/native_e2e/src/lib.rs
@@ -202,6 +202,15 @@ fn e2e_main() {
     }
     win.set_opacity(1.0);
 
+    win.set_click_passthrough(true);
+    let passthrough = wait_for(|| win.get_click_passthrough(), 25, 20).await;
+    win.set_click_passthrough(false);
+    if passthrough {
+      check("set_click_passthrough round-trips", true);
+    } else {
+      na("set_click_passthrough (backend doesn't reflect the toggle)");
+    }
+
     // Visibility.
     win.show();
     let visible = wait_for(|| win.get_visible(), 25, 20).await;

--- a/webview/src/runtime_loader.cc
+++ b/webview/src/runtime_loader.cc
@@ -228,6 +228,24 @@ static double Backend_GetWindowOpacity(void* data, uint32_t window_id) {
   return 1.0;
 }
 
+static void Backend_SetClickPassthrough(void* data, uint32_t window_id,
+                                        bool enabled) {
+  RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);
+  LaufeyBackend* backend = loader->GetBackend();
+  if (backend) {
+    backend->SetClickPassthrough(window_id, enabled);
+  }
+}
+
+static bool Backend_IsClickPassthrough(void* data, uint32_t window_id) {
+  RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);
+  LaufeyBackend* backend = loader->GetBackend();
+  if (backend) {
+    return backend->IsClickPassthrough(window_id);
+  }
+  return false;
+}
+
 static bool Backend_IsVisible(void* data, uint32_t window_id) {
   RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);
   LaufeyBackend* backend = loader->GetBackend();
@@ -740,6 +758,8 @@ void RuntimeLoader::InitializeBackendApi() {
   backend_api_.is_always_on_top = Backend_IsAlwaysOnTop;
   backend_api_.set_window_opacity = Backend_SetWindowOpacity;
   backend_api_.get_window_opacity = Backend_GetWindowOpacity;
+  backend_api_.set_click_passthrough = Backend_SetClickPassthrough;
+  backend_api_.is_click_passthrough = Backend_IsClickPassthrough;
   backend_api_.is_visible = Backend_IsVisible;
   backend_api_.show = Backend_Show;
   backend_api_.hide = Backend_Hide;

--- a/webview/src/runtime_loader.h
+++ b/webview/src/runtime_loader.h
@@ -402,6 +402,13 @@ class LaufeyBackend {
   virtual double GetWindowOpacity(uint32_t /*window_id*/) {
     return 1.0;
   }
+  // Click passthrough (API >= 33): while enabled the window ignores all mouse
+  // input and events fall through to whatever is beneath it. Default no-op /
+  // reports disabled; platform backends override.
+  virtual void SetClickPassthrough(uint32_t /*window_id*/, bool /*enabled*/) {}
+  virtual bool IsClickPassthrough(uint32_t /*window_id*/) {
+    return false;
+  }
   virtual bool IsVisible(uint32_t window_id) = 0;
   virtual void Show(uint32_t window_id) = 0;
   virtual void Hide(uint32_t window_id) = 0;

--- a/webview/src/webview_linux.cc
+++ b/webview/src/webview_linux.cc
@@ -113,6 +113,8 @@ struct LinuxWindowState {
   GtkWidget* menu_bar;  // per-window menu bar (nullptr = none)
   WebKitWebView* webview;
   WebKitUserContentManager* content_manager;
+  // GTK has no getter for the input shape region, so remember what we set.
+  bool click_passthrough = false;
 };
 
 // Track the click_count from press events for use in the corresponding release.
@@ -360,6 +362,8 @@ class WebKitGTKBackend : public LaufeyBackend {
   bool IsAlwaysOnTop(uint32_t window_id) override;
   void SetWindowOpacity(uint32_t window_id, double opacity) override;
   double GetWindowOpacity(uint32_t window_id) override;
+  void SetClickPassthrough(uint32_t window_id, bool enabled) override;
+  bool IsClickPassthrough(uint32_t window_id) override;
   bool IsVisible(uint32_t window_id) override;
   void Show(uint32_t window_id) override;
   void Hide(uint32_t window_id) override;
@@ -1051,6 +1055,40 @@ double WebKitGTKBackend::GetWindowOpacity(uint32_t window_id) {
     auto* state = GetWindow(window_id);
     if (state) {
       result = gtk_widget_get_opacity(state->window);
+    }
+  });
+  return result;
+}
+
+void WebKitGTKBackend::SetClickPassthrough(uint32_t window_id, bool enabled) {
+  gtk_invoke_sync([&] {
+    std::lock_guard<std::mutex> lock(windows_mutex_);
+    auto* state = GetWindow(window_id);
+    if (!state)
+      return;
+    if (enabled) {
+      // An empty input shape makes the whole window transparent to pointer
+      // events; they fall through to whatever is beneath. Best-effort under a
+      // reparenting X11 window manager (the WM frame may still catch clicks),
+      // so pair it with a frameless window.
+      cairo_region_t* empty = cairo_region_create();
+      gtk_widget_input_shape_combine_region(state->window, empty);
+      cairo_region_destroy(empty);
+    } else {
+      // NULL restores the default input shape (the full window).
+      gtk_widget_input_shape_combine_region(state->window, nullptr);
+    }
+    state->click_passthrough = enabled;
+  });
+}
+
+bool WebKitGTKBackend::IsClickPassthrough(uint32_t window_id) {
+  bool result = false;
+  gtk_invoke_sync([&] {
+    std::lock_guard<std::mutex> lock(windows_mutex_);
+    auto* state = GetWindow(window_id);
+    if (state) {
+      result = state->click_passthrough;
     }
   });
   return result;

--- a/webview/src/webview_macos.mm
+++ b/webview/src/webview_macos.mm
@@ -67,6 +67,8 @@ class WKWebViewBackend : public LaufeyBackend {
   bool IsAlwaysOnTop(uint32_t window_id) override;
   void SetWindowOpacity(uint32_t window_id, double opacity) override;
   double GetWindowOpacity(uint32_t window_id) override;
+  void SetClickPassthrough(uint32_t window_id, bool enabled) override;
+  bool IsClickPassthrough(uint32_t window_id) override;
   bool IsVisible(uint32_t window_id) override;
   void Show(uint32_t window_id) override;
   void Hide(uint32_t window_id) override;
@@ -1501,6 +1503,30 @@ double WKWebViewBackend::GetWindowOpacity(uint32_t window_id) {
     auto* state = GetWindow(window_id);
     if (state) {
       result = (double)[state->window alphaValue];
+    }
+  });
+  return result;
+}
+
+void WKWebViewBackend::SetClickPassthrough(uint32_t window_id, bool enabled) {
+  dispatch_async(dispatch_get_main_queue(), ^{
+    @autoreleasepool {
+      std::lock_guard<std::mutex> lock(windows_mutex_);
+      auto* state = GetWindow(window_id);
+      if (state) {
+        [state->window setIgnoresMouseEvents:enabled];
+      }
+    }
+  });
+}
+
+bool WKWebViewBackend::IsClickPassthrough(uint32_t window_id) {
+  __block bool result = false;
+  dispatch_sync(dispatch_get_main_queue(), ^{
+    std::lock_guard<std::mutex> lock(windows_mutex_);
+    auto* state = GetWindow(window_id);
+    if (state) {
+      result = [state->window ignoresMouseEvents];
     }
   });
   return result;

--- a/webview/src/webview_windows.cc
+++ b/webview/src/webview_windows.cc
@@ -316,6 +316,8 @@ class WebView2Backend : public LaufeyBackend {
   bool IsAlwaysOnTop(uint32_t window_id) override;
   void SetWindowOpacity(uint32_t window_id, double opacity) override;
   double GetWindowOpacity(uint32_t window_id) override;
+  void SetClickPassthrough(uint32_t window_id, bool enabled) override;
+  bool IsClickPassthrough(uint32_t window_id) override;
   bool IsVisible(uint32_t window_id) override;
   void Show(uint32_t window_id) override;
   void Hide(uint32_t window_id) override;
@@ -1251,11 +1253,17 @@ void WebView2Backend::SetWindowOpacity(uint32_t window_id, double opacity) {
   LONG ex = GetWindowLong(state->hwnd, GWL_EXSTYLE);
   if (opacity >= 1.0) {
     // Fully opaque: drop the layered style so the window renders on the normal
-    // (non-redirected) path with no per-window alpha overhead.
+    // (non-redirected) path with no per-window alpha overhead. Exception:
+    // click passthrough (WS_EX_TRANSPARENT) only works on a layered window,
+    // so keep the style and just reset the alpha while it's active.
     if (ex & WS_EX_LAYERED) {
-      SetWindowLong(state->hwnd, GWL_EXSTYLE, ex & ~WS_EX_LAYERED);
-      RedrawWindow(state->hwnd, nullptr, nullptr,
-                   RDW_ERASE | RDW_INVALIDATE | RDW_FRAME | RDW_ALLCHILDREN);
+      if (ex & WS_EX_TRANSPARENT) {
+        SetLayeredWindowAttributes(state->hwnd, 0, 255, LWA_ALPHA);
+      } else {
+        SetWindowLong(state->hwnd, GWL_EXSTYLE, ex & ~WS_EX_LAYERED);
+        RedrawWindow(state->hwnd, nullptr, nullptr,
+                     RDW_ERASE | RDW_INVALIDATE | RDW_FRAME | RDW_ALLCHILDREN);
+      }
     }
     return;
   }
@@ -1280,6 +1288,60 @@ double WebView2Backend::GetWindowOpacity(uint32_t window_id) {
     return alpha / 255.0;
   }
   return 1.0;
+}
+
+void WebView2Backend::SetClickPassthrough(uint32_t window_id, bool enabled) {
+  if (GetCurrentThreadId() != ui_thread_id_) {
+    RunOnUiThread([this, window_id, enabled] {
+      SetClickPassthrough(window_id, enabled);
+    });
+    return;
+  }
+  std::lock_guard<std::recursive_mutex> lock(windows_mutex_);
+  auto* state = GetWindow(window_id);
+  if (!state)
+    return;
+  LONG ex = GetWindowLong(state->hwnd, GWL_EXSTYLE);
+  if (enabled) {
+    // WS_EX_TRANSPARENT excludes the whole top-level window (children
+    // included, so also the WebView2 host) from mouse hit-testing, but only
+    // takes effect on a layered window.
+    bool newly_layered = !(ex & WS_EX_LAYERED);
+    SetWindowLong(state->hwnd, GWL_EXSTYLE,
+                  ex | WS_EX_TRANSPARENT | WS_EX_LAYERED);
+    if (newly_layered) {
+      // A window that just became layered renders nothing until its
+      // transparency attributes are set; fully opaque keeps it visually
+      // unchanged.
+      SetLayeredWindowAttributes(state->hwnd, 0, 255, LWA_ALPHA);
+    }
+  } else {
+    LONG new_ex = ex & ~WS_EX_TRANSPARENT;
+    // Drop the layered style too unless a window opacity < 1.0 still needs it.
+    BYTE alpha = 255;
+    DWORD flags = 0;
+    bool has_alpha =
+        (ex & WS_EX_LAYERED) &&
+        GetLayeredWindowAttributes(state->hwnd, nullptr, &alpha, &flags) &&
+        (flags & LWA_ALPHA) && alpha < 255;
+    if (!has_alpha)
+      new_ex &= ~WS_EX_LAYERED;
+    if (new_ex != ex) {
+      SetWindowLong(state->hwnd, GWL_EXSTYLE, new_ex);
+      if ((ex & WS_EX_LAYERED) && !(new_ex & WS_EX_LAYERED)) {
+        RedrawWindow(state->hwnd, nullptr, nullptr,
+                     RDW_ERASE | RDW_INVALIDATE | RDW_FRAME | RDW_ALLCHILDREN);
+      }
+    }
+  }
+}
+
+bool WebView2Backend::IsClickPassthrough(uint32_t window_id) {
+  std::lock_guard<std::recursive_mutex> lock(windows_mutex_);
+  auto* state = GetWindow(window_id);
+  return state ? (GetWindowLong(state->hwnd, GWL_EXSTYLE) &
+                  WS_EX_TRANSPARENT) != 0
+               : false;
 }
 
 bool WebView2Backend::IsVisible(uint32_t window_id) {

--- a/winit/src/main.rs
+++ b/winit/src/main.rs
@@ -214,6 +214,7 @@ impl ApplicationHandler<UserEvent> for App {
             | CommonEvent::SetWindowPosition { window_id }
             | CommonEvent::SetResizable { window_id }
             | CommonEvent::SetAlwaysOnTop { window_id }
+            | CommonEvent::SetClickPassthrough { window_id }
             | CommonEvent::Show { window_id }
             | CommonEvent::Hide { window_id }
             | CommonEvent::Focus { window_id }


### PR DESCRIPTION
Adds a `set_click_passthrough` / `is_click_passthrough` pair to the backend C ABI (**API version 32 → 33**). While enabled, the window ignores all mouse input — clicks, moves, wheel — and events fall through to whatever window is beneath it, like Electron's `setIgnoreMouseEvents(true)`. Keyboard input is unaffected. It is a live setter intended for frameless/transparent overlay windows (HUDs, notification toasts, screen annotations).

## Rust API

```rust
let overlay = Window::new_with_options(
  400, 300,
  WindowOptions { frameless: true, transparent: true, ..Default::default() },
)
.always_on_top(true)
.click_passthrough(true)   // builder
.load("overlay.html");

overlay.set_click_passthrough(false); // live toggle
overlay.get_click_passthrough();
```

## Backend implementations

| Backend | Mechanism |
| --- | --- |
| webview/macOS, CEF/macOS | `NSWindow.ignoresMouseEvents` |
| webview/Windows, CEF/Windows | `WS_EX_TRANSPARENT \| WS_EX_LAYERED` on the top-level window, which excludes it (children — i.e. the WebView2/CEF widget HWNDs — included) from mouse hit-testing |
| webview/Linux (GTK) | empty input shape via `gtk_widget_input_shape_combine_region` |
| CEF/Linux | same, through a foreign `GdkWindow` wrapped around the X11 xid — reuses GDK's XShape linkage, no new library dependency |
| winit | `Window::set_cursor_hittest`, applied both live and at window creation |

Notes:

- **Windows opacity interaction**: `WS_EX_TRANSPARENT` only works on a layered window, and `set_window_opacity(1.0)` used to drop `WS_EX_LAYERED`. The return-to-opaque branch (both WebView2 and CEF) now keeps the layered style while passthrough is active and just resets the alpha; disabling passthrough drops the layered style only when no fractional opacity still needs it.
- **Linux is best-effort under a reparenting X11 WM** (the WM frame may still catch clicks) — pair it with a frameless window, which is the intended overlay use case anyway. Documented in `docs/window-management.md`.
- iOS webview inherits the base-class no-op.

## Testing

- `cargo test -p laufey`: 45 tests pass.
- New `set_click_passthrough round-trips` probe in the `native_e2e` battery (capability-probed like always-on-top/opacity: N/A rather than FAIL where a backend/WM doesn't reflect the toggle).
- Ran the battery live on macOS under all three backends: **winit** ✅, **WebView** ✅ (overall PASS), **CEF** ✅ (overall PASS).
- Windows and Linux C++ paths follow the existing per-platform patterns but were not compiled here — needs a CI run.

Pre-existing issues seen while testing, unrelated to this PR: the winit e2e `set_size` round-trip FAILs on clean main on this machine, and clippy trips a macOS-only `unused_mut` in `store_window_handles` (the variable is only assigned under `#[cfg(target_os = "linux")]`).