### PR TITLE
feat: add click passthrough forwarding (observe events while passing through)

### DIFF
--- a/backend-winit-common/src/lib.rs
+++ b/backend-winit-common/src/lib.rs
@@ -33,7 +33,7 @@ use winit::window::{Window, WindowLevel};
 // Bumping this in lockstep with the capi is mandatory: the capi's `init_api`
 // rejects any backend whose reported `version` differs, and the vtable layout
 // below must match the `laufey_backend_api` struct as of this version.
-pub const LAUFEY_API_VERSION: u32 = 33;
+pub const LAUFEY_API_VERSION: u32 = 34;
 
 /// Creation-time window style flags (mirror `LAUFEY_WINDOW_FLAG_*` in laufey.h).
 pub const LAUFEY_WINDOW_FLAG_FRAMELESS: u32 = 1 << 0;
@@ -553,6 +553,16 @@ pub struct LaufeyBackendApi {
   pub set_click_passthrough:
     Option<unsafe extern "C" fn(*mut c_void, u32, bool)>,
   pub is_click_passthrough:
+    Option<unsafe extern "C" fn(*mut c_void, u32) -> bool>,
+
+  // --- Click passthrough forwarding (API >= 34) ---
+  // winit has no global input observation API, so both pointers stay None and
+  // the embedder's forward toggle is a no-op (getter reports false). The
+  // fields MUST still be declared to keep the struct layout in sync with the
+  // `laufey_backend_api` the capi reads through the backend's pointer.
+  pub set_click_passthrough_forward:
+    Option<unsafe extern "C" fn(*mut c_void, u32, bool)>,
+  pub is_click_passthrough_forward:
     Option<unsafe extern "C" fn(*mut c_void, u32) -> bool>,
 }
 
@@ -1192,6 +1202,10 @@ pub fn create_api_base() -> LaufeyBackendApi {
     // Click passthrough (API >= 33): filled by fill_common_api.
     set_click_passthrough: None,
     is_click_passthrough: None,
+    // Click passthrough forwarding (API >= 34): winit has no global input
+    // observation API.
+    set_click_passthrough_forward: None,
+    is_click_passthrough_forward: None,
   }
 }
 

--- a/capi/include/laufey.h
+++ b/capi/include/laufey.h
@@ -11,7 +11,7 @@
 extern "C" {
 #endif
 
-#define LAUFEY_API_VERSION 33
+#define LAUFEY_API_VERSION 34
 
 // Window handle types for get_window_handle_type
 #define LAUFEY_WINDOW_HANDLE_UNKNOWN 0
@@ -811,6 +811,36 @@ struct laufey_backend_api {
   // Returns false if the id is unknown or the backend can't report it. NULL
   // on backends older than API version 33.
   bool (*is_click_passthrough)(void* backend_data, uint32_t window_id);
+
+  // --- Click passthrough forwarding (API >= 34) ------------------------------
+  //
+  // While a window has click passthrough enabled, forwarding keeps the
+  // embedder's mouse handlers (set_mouse_click_handler /
+  // set_mouse_move_handler / set_wheel_handler) fed for that window even
+  // though the OS delivers the events to whatever is beneath it — like
+  // Electron's setIgnoreMouseEvents(true, { forward: true }). Observation
+  // only: the events cannot be consumed (the window below still receives
+  // them), and by the time a handler runs the OS has already routed the
+  // event. Delivery comes from a global OS observer that hit-tests the
+  // window's frame, so events are reported only while passthrough is active
+  // and the cursor is over the (visible) window; while passthrough is
+  // disabled the flag has no effect — normal per-window delivery already
+  // fires the handlers. Enables the standard interactive-overlay pattern:
+  // observe moves, toggle passthrough off when the cursor enters an
+  // interactive region.
+  //
+  // Implemented on macOS (NSEvent global monitor; mouse observation needs no
+  // extra permission). Backends/platforms without global observation
+  // (Windows, Linux, winit — see docs/window-management.md) currently ignore
+  // the flag and report false from the getter. NULL on backends older than
+  // API version 34; callers must null-check.
+  void (*set_click_passthrough_forward)(void* backend_data, uint32_t window_id,
+                                        bool forward);
+
+  // Return whether forwarding is currently enabled for the window. Returns
+  // false if the id is unknown or the backend doesn't support forwarding.
+  // NULL on backends older than API version 34.
+  bool (*is_click_passthrough_forward)(void* backend_data, uint32_t window_id);
 };
 
 #ifdef __cplusplus

--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -29,7 +29,7 @@ pub use mouse::*;
 /// (`github.com/denoland/laufey/releases/tag/v{VERSION}`).
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-pub const LAUFEY_API_VERSION: u32 = 33;
+pub const LAUFEY_API_VERSION: u32 = 34;
 
 /// Creation-time window style flags for [`Window::new_with_options`].
 /// Mirror the `LAUFEY_WINDOW_FLAG_*` constants in `laufey.h`.
@@ -950,6 +950,44 @@ impl Window {
   pub fn get_click_passthrough(&self) -> bool {
     let api = api();
     if let Some(f) = api.is_click_passthrough {
+      unsafe { f(api.backend_data, self.id) }
+    } else {
+      false
+    }
+  }
+
+  /// Builder form of [`Window::set_click_passthrough_forward`].
+  pub fn click_passthrough_forward(self, forward: bool) -> Self {
+    self.set_click_passthrough_forward(forward);
+    self
+  }
+
+  /// While click passthrough is enabled, keep this window's mouse events
+  /// flowing to the registered [`Window::on_mouse_click`] /
+  /// [`Window::on_mouse_move`] / [`Window::on_wheel`] handlers even though
+  /// the OS delivers them to whatever is
+  /// beneath the window — like Electron's
+  /// `setIgnoreMouseEvents(true, { forward: true })`. Observation only: the
+  /// events cannot be consumed, and they are reported only while passthrough
+  /// is active and the cursor is over the visible window. This enables the
+  /// standard interactive-overlay pattern: watch mouse moves and call
+  /// [`Window::set_click_passthrough`]`(false)` when the cursor enters an
+  /// interactive region.
+  ///
+  /// Currently implemented on macOS; other platforms ignore the flag (see
+  /// the click-passthrough section of the window-management docs).
+  pub fn set_click_passthrough_forward(&self, forward: bool) {
+    let api = api();
+    if let Some(f) = api.set_click_passthrough_forward {
+      unsafe { f(api.backend_data, self.id, forward) };
+    }
+  }
+
+  /// Get whether click-passthrough forwarding is currently enabled. Returns
+  /// `false` when the backend does not support forwarding.
+  pub fn get_click_passthrough_forward(&self) -> bool {
+    let api = api();
+    if let Some(f) = api.is_click_passthrough_forward {
       unsafe { f(api.backend_data, self.id) }
     } else {
       false

--- a/cef/src/runtime_loader.cc
+++ b/cef/src/runtime_loader.cc
@@ -593,6 +593,44 @@ static bool Backend_IsClickPassthrough(void* data, uint32_t window_id) {
   return result;
 }
 
+static void Backend_SetClickPassthroughForward(void* data, uint32_t window_id,
+                                               bool forward) {
+#ifdef __APPLE__
+  RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);
+  CefRefPtr<CefBrowser> browser = loader->GetBrowserForWindow(window_id);
+  if (browser) {
+    CefPostTask(TID_UI, base::BindOnce(
+                            [](uint32_t wid, bool fwd) {
+                              SetNSWindowClickPassthroughForward(wid, fwd);
+                            },
+                            window_id, forward));
+  }
+#else
+  // Forwarding needs a global input observer; not implemented on this
+  // platform yet (see docs/window-management.md).
+  (void)data;
+  (void)window_id;
+  (void)forward;
+#endif
+}
+
+static bool Backend_IsClickPassthroughForward(void* data, uint32_t window_id) {
+#ifdef __APPLE__
+  RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);
+  CefRefPtr<CefBrowser> browser = loader->GetBrowserForWindow(window_id);
+  bool result = false;
+  if (browser) {
+    cef_invoke_sync(
+        [&] { result = IsNSWindowClickPassthroughForward(window_id); });
+  }
+  return result;
+#else
+  (void)data;
+  (void)window_id;
+  return false;
+#endif
+}
+
 static bool Backend_IsVisible(void* data, uint32_t window_id) {
   RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);
   CefRefPtr<CefBrowser> browser = loader->GetBrowserForWindow(window_id);
@@ -1745,6 +1783,9 @@ void RuntimeLoader::InitializeBackendApi() {
   backend_api_.get_window_opacity = Backend_GetWindowOpacity;
   backend_api_.set_click_passthrough = Backend_SetClickPassthrough;
   backend_api_.is_click_passthrough = Backend_IsClickPassthrough;
+  backend_api_.set_click_passthrough_forward =
+      Backend_SetClickPassthroughForward;
+  backend_api_.is_click_passthrough_forward = Backend_IsClickPassthroughForward;
   backend_api_.is_visible = Backend_IsVisible;
   backend_api_.show = Backend_Show;
   backend_api_.hide = Backend_Hide;

--- a/cef/src/runtime_loader.h
+++ b/cef/src/runtime_loader.h
@@ -515,6 +515,13 @@ double GetNSWindowOpacity(void* cef_handle);
 // input falls through to whatever is beneath the window.
 void SetNSWindowClickPassthrough(void* cef_handle, bool enabled);
 bool IsNSWindowClickPassthrough(void* cef_handle);
+// Click-passthrough forwarding: while a window is passthrough, keep feeding
+// its mouse events to the laufey mouse handlers from an NSEvent *global*
+// monitor (events delivered to other apps). Keyed by laufey window id since
+// the flag and monitors are app-scoped state, not NSWindow state. Main
+// thread only.
+void SetNSWindowClickPassthroughForward(uint32_t window_id, bool forward);
+bool IsNSWindowClickPassthroughForward(uint32_t window_id);
 // Reconfigure the window backing a CEF handle to behave as a floating,
 // non-activating utility panel (used for tray popovers): floats above
 // normal windows, joins all spaces, and doesn't steal focus from the

--- a/cef/src/runtime_loader_mac.mm
+++ b/cef/src/runtime_loader_mac.mm
@@ -186,6 +186,205 @@ static uint32_t LaufeyIdForNSWindow(NSWindow* win) {
       (__bridge void*)win);
 }
 
+// --- Click passthrough forwarding (macOS) ---
+//
+// While a window is passthrough (ignoresMouseEvents), its events are
+// delivered to other applications, so the local monitors below never see
+// them. Forwarding installs NSEvent *global* monitors — which observe
+// exactly those other-app events — hit-tests the frames of forwarding
+// windows, and re-dispatches through the same RuntimeLoader mouse paths.
+// All state is touched on the main thread only (CEF's browser UI thread).
+
+static std::map<uint32_t, bool> g_forward_flags;
+static id g_forward_mouse_monitor = nil;
+static id g_forward_mouse_move_monitor = nil;
+static id g_forward_scroll_monitor = nil;
+
+// A global-monitor event carries no NSWindow, so locationInWindow is already
+// in screen coordinates; keep a defensive branch for the window-ful case.
+static NSPoint ForwardScreenPoint(NSEvent* event) {
+  return [event window]
+             ? [[event window] convertPointToScreen:[event locationInWindow]]
+             : [event locationInWindow];
+}
+
+// Frontmost visible passthrough+forwarding window whose frame contains
+// `screen_point`, or 0. orderedWindows is front-to-back, so overlapping
+// forwarding windows resolve to the one visually on top.
+static uint32_t ForwardTargetAt(NSPoint screen_point, NSWindow** out_win) {
+  for (NSWindow* win in [NSApp orderedWindows]) {
+    uint32_t wid = LaufeyIdForNSWindow(win);
+    if (wid == 0)
+      continue;
+    auto it = g_forward_flags.find(wid);
+    if (it == g_forward_flags.end() || !it->second)
+      continue;
+    // Without ignoresMouseEvents an event over this frame that reached
+    // another app was simply over an occluding window — not forwarded.
+    if (![win ignoresMouseEvents] || ![win isVisible])
+      continue;
+    if (!NSPointInRect(screen_point, [win frame]))
+      continue;
+    if (out_win)
+      *out_win = win;
+    return wid;
+  }
+  return 0;
+}
+
+static void UpdateForwardMonitors() {
+  bool any_forwarding = false;
+  for (auto& [id, flag] : g_forward_flags) {
+    if (flag) {
+      any_forwarding = true;
+      break;
+    }
+  }
+
+  if (!any_forwarding) {
+    if (g_forward_mouse_monitor) {
+      [NSEvent removeMonitor:g_forward_mouse_monitor];
+      g_forward_mouse_monitor = nil;
+    }
+    if (g_forward_mouse_move_monitor) {
+      [NSEvent removeMonitor:g_forward_mouse_move_monitor];
+      g_forward_mouse_move_monitor = nil;
+    }
+    if (g_forward_scroll_monitor) {
+      [NSEvent removeMonitor:g_forward_scroll_monitor];
+      g_forward_scroll_monitor = nil;
+    }
+    return;
+  }
+  if (g_forward_mouse_monitor)
+    return;
+
+  g_forward_mouse_monitor = [NSEvent
+      addGlobalMonitorForEventsMatchingMask:(NSEventMaskLeftMouseDown |
+                                             NSEventMaskLeftMouseUp |
+                                             NSEventMaskRightMouseDown |
+                                             NSEventMaskRightMouseUp |
+                                             NSEventMaskOtherMouseDown |
+                                             NSEventMaskOtherMouseUp)
+                                    handler:^(NSEvent* event) {
+                                      NSPoint screen_point =
+                                          ForwardScreenPoint(event);
+                                      NSWindow* win = nil;
+                                      uint32_t wid =
+                                          ForwardTargetAt(screen_point, &win);
+                                      if (wid == 0)
+                                        return;
+
+                                      int state;
+                                      switch ([event type]) {
+                                        case NSEventTypeLeftMouseDown:
+                                        case NSEventTypeRightMouseDown:
+                                        case NSEventTypeOtherMouseDown:
+                                          state = LAUFEY_MOUSE_PRESSED;
+                                          break;
+                                        default:
+                                          state = LAUFEY_MOUSE_RELEASED;
+                                          break;
+                                      }
+                                      int button = NSButtonToLaufey(
+                                          [event buttonNumber]);
+                                      uint32_t modifiers =
+                                          NSModifierFlagsToLaufey(
+                                              [event modifierFlags]);
+                                      int32_t click_count =
+                                          (int32_t)[event clickCount];
+
+                                      NSPoint local = [win
+                                          convertPointFromScreen:screen_point];
+                                      double x = local.x;
+                                      double y =
+                                          [win contentLayoutRect].size.height -
+                                          local.y;
+
+                                      RuntimeLoader::GetInstance()
+                                          ->DispatchMouseClickEvent(
+                                              wid, state, button, x, y,
+                                              modifiers, click_count);
+                                    }];
+
+  g_forward_mouse_move_monitor = [NSEvent
+      addGlobalMonitorForEventsMatchingMask:(NSEventMaskMouseMoved |
+                                             NSEventMaskLeftMouseDragged |
+                                             NSEventMaskRightMouseDragged |
+                                             NSEventMaskOtherMouseDragged)
+                                    handler:^(NSEvent* event) {
+                                      NSPoint screen_point =
+                                          ForwardScreenPoint(event);
+                                      NSWindow* win = nil;
+                                      uint32_t wid =
+                                          ForwardTargetAt(screen_point, &win);
+                                      if (wid == 0)
+                                        return;
+
+                                      uint32_t modifiers =
+                                          NSModifierFlagsToLaufey(
+                                              [event modifierFlags]);
+                                      NSPoint local = [win
+                                          convertPointFromScreen:screen_point];
+                                      double x = local.x;
+                                      double y =
+                                          [win contentLayoutRect].size.height -
+                                          local.y;
+
+                                      RuntimeLoader::GetInstance()
+                                          ->DispatchMouseMoveEvent(wid, x, y,
+                                                                   modifiers);
+                                    }];
+
+  g_forward_scroll_monitor = [NSEvent
+      addGlobalMonitorForEventsMatchingMask:NSEventMaskScrollWheel
+                                    handler:^(NSEvent* event) {
+                                      NSPoint screen_point =
+                                          ForwardScreenPoint(event);
+                                      NSWindow* win = nil;
+                                      uint32_t wid =
+                                          ForwardTargetAt(screen_point, &win);
+                                      if (wid == 0)
+                                        return;
+
+                                      double delta_x = [event scrollingDeltaX];
+                                      double delta_y = [event scrollingDeltaY];
+                                      uint32_t modifiers =
+                                          NSModifierFlagsToLaufey(
+                                              [event modifierFlags]);
+                                      int32_t delta_mode =
+                                          [event hasPreciseScrollingDeltas]
+                                              ? LAUFEY_WHEEL_DELTA_PIXEL
+                                              : LAUFEY_WHEEL_DELTA_LINE;
+
+                                      NSPoint local = [win
+                                          convertPointFromScreen:screen_point];
+                                      double x = local.x;
+                                      double y =
+                                          [win contentLayoutRect].size.height -
+                                          local.y;
+
+                                      RuntimeLoader::GetInstance()
+                                          ->DispatchWheelEvent(
+                                              wid, delta_x, delta_y, x, y,
+                                              modifiers, delta_mode);
+                                    }];
+}
+
+void SetNSWindowClickPassthroughForward(uint32_t window_id, bool forward) {
+  if (forward) {
+    g_forward_flags[window_id] = true;
+  } else {
+    g_forward_flags.erase(window_id);
+  }
+  UpdateForwardMonitors();
+}
+
+bool IsNSWindowClickPassthroughForward(uint32_t window_id) {
+  auto it = g_forward_flags.find(window_id);
+  return it != g_forward_flags.end() && it->second;
+}
+
 // Per-window menu storage (must be declared before focus observer uses them)
 static std::map<uint32_t, NSMenu*> g_window_menus;
 static std::mutex g_window_menus_mutex;

--- a/docs/window-management.md
+++ b/docs/window-management.md
@@ -109,3 +109,45 @@ Platform notes:
   case) for reliable behavior.
 - The Winit backend uses winit's `set_cursor_hittest`, with the same platform
   behavior as above.
+
+### Forwarding: passthrough, but still observing events
+
+`Window::click_passthrough_forward` / `set_click_passthrough_forward` /
+`get_click_passthrough_forward` keeps the window's mouse events flowing to your
+registered `on_mouse_move` / `on_mouse_click` / `on_wheel` handlers _while_
+passthrough is active — like Electron's
+`setIgnoreMouseEvents(true, { forward: true })`. The OS still delivers every
+event to the window beneath; forwarding is observation only, sourced from a
+global input observer that hit-tests the overlay's frame. While passthrough is
+disabled the flag has no effect, because normal per-window delivery already
+fires the handlers.
+
+You cannot selectively consume a forwarded event — hit-testing is decided by the
+OS before your handler runs. The standard interactive-overlay pattern instead
+toggles passthrough just-in-time: watch forwarded mouse moves and disable
+passthrough when the cursor enters an interactive region, re-enable it on leave.
+
+```rust
+let overlay = Window::new_with_options(
+  400,
+  300,
+  WindowOptions { frameless: true, transparent: true, ..Default::default() },
+)
+.always_on_top(true)
+.click_passthrough(true)
+.click_passthrough_forward(true)
+.on_mouse_move(move |ev| {
+  // e.g. flip set_click_passthrough(false) when (ev.x, ev.y) is over a button
+})
+.load("overlay.html");
+```
+
+Platform support: implemented on **macOS** (an `NSEvent` global monitor —
+observing mouse events needs no extra permission) for the WebView and CEF
+backends. **Windows** (a `WH_MOUSE_LL` hook), **Linux/X11** (XInput2 raw
+events), and the Winit backend are not implemented yet and ignore the flag (the
+getter reports `false`); **Linux/Wayland** cannot support it — the compositor
+does not expose global input. One macOS caveat: global monitors never see events
+delivered to your _own_ application, so if the event lands on another
+(non-passthrough) window of the same app that overlaps the overlay, the
+overlay's handlers do not fire for it.

--- a/examples/native_e2e/src/lib.rs
+++ b/examples/native_e2e/src/lib.rs
@@ -211,6 +211,18 @@ fn e2e_main() {
       na("set_click_passthrough (backend doesn't reflect the toggle)");
     }
 
+    // Forwarding is macOS-only for now; elsewhere the setter is a no-op and
+    // the getter reports false, which this treats as N/A. Whether forwarded
+    // events actually arrive needs real OS input and is not probed here.
+    win.set_click_passthrough_forward(true);
+    let forward = wait_for(|| win.get_click_passthrough_forward(), 25, 20).await;
+    win.set_click_passthrough_forward(false);
+    if forward {
+      check("set_click_passthrough_forward round-trips", true);
+    } else {
+      na("set_click_passthrough_forward (platform doesn't support forwarding)");
+    }
+
     // Visibility.
     win.show();
     let visible = wait_for(|| win.get_visible(), 25, 20).await;

--- a/webview/src/runtime_loader.cc
+++ b/webview/src/runtime_loader.cc
@@ -246,6 +246,24 @@ static bool Backend_IsClickPassthrough(void* data, uint32_t window_id) {
   return false;
 }
 
+static void Backend_SetClickPassthroughForward(void* data, uint32_t window_id,
+                                               bool forward) {
+  RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);
+  LaufeyBackend* backend = loader->GetBackend();
+  if (backend) {
+    backend->SetClickPassthroughForward(window_id, forward);
+  }
+}
+
+static bool Backend_IsClickPassthroughForward(void* data, uint32_t window_id) {
+  RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);
+  LaufeyBackend* backend = loader->GetBackend();
+  if (backend) {
+    return backend->IsClickPassthroughForward(window_id);
+  }
+  return false;
+}
+
 static bool Backend_IsVisible(void* data, uint32_t window_id) {
   RuntimeLoader* loader = static_cast<RuntimeLoader*>(data);
   LaufeyBackend* backend = loader->GetBackend();
@@ -760,6 +778,9 @@ void RuntimeLoader::InitializeBackendApi() {
   backend_api_.get_window_opacity = Backend_GetWindowOpacity;
   backend_api_.set_click_passthrough = Backend_SetClickPassthrough;
   backend_api_.is_click_passthrough = Backend_IsClickPassthrough;
+  backend_api_.set_click_passthrough_forward =
+      Backend_SetClickPassthroughForward;
+  backend_api_.is_click_passthrough_forward = Backend_IsClickPassthroughForward;
   backend_api_.is_visible = Backend_IsVisible;
   backend_api_.show = Backend_Show;
   backend_api_.hide = Backend_Hide;

--- a/webview/src/runtime_loader.h
+++ b/webview/src/runtime_loader.h
@@ -409,6 +409,16 @@ class LaufeyBackend {
   virtual bool IsClickPassthrough(uint32_t /*window_id*/) {
     return false;
   }
+  // Click passthrough forwarding (API >= 34): while passthrough is enabled,
+  // keep the embedder's mouse handlers fed for this window from a global OS
+  // observer even though the OS delivers the events elsewhere. Observation
+  // only. Default no-op / reports disabled; platforms with global input
+  // observation (macOS) override.
+  virtual void SetClickPassthroughForward(uint32_t /*window_id*/,
+                                          bool /*forward*/) {}
+  virtual bool IsClickPassthroughForward(uint32_t /*window_id*/) {
+    return false;
+  }
   virtual bool IsVisible(uint32_t window_id) = 0;
   virtual void Show(uint32_t window_id) = 0;
   virtual void Hide(uint32_t window_id) = 0;

--- a/webview/src/webview_macos.mm
+++ b/webview/src/webview_macos.mm
@@ -39,6 +39,9 @@ struct MacWindowState {
   LaufeyUIDelegate* ui_delegate;
   LaufeyNavigationDelegate* navigation_delegate;
   id title_observer = nil;  // KVO observer mirroring document.title
+  // While click passthrough is active, keep feeding this window's mouse
+  // events from the global (other-app) monitors.
+  bool click_passthrough_forward = false;
 };
 
 class WKWebViewBackend : public LaufeyBackend {
@@ -69,6 +72,8 @@ class WKWebViewBackend : public LaufeyBackend {
   double GetWindowOpacity(uint32_t window_id) override;
   void SetClickPassthrough(uint32_t window_id, bool enabled) override;
   bool IsClickPassthrough(uint32_t window_id) override;
+  void SetClickPassthroughForward(uint32_t window_id, bool forward) override;
+  bool IsClickPassthroughForward(uint32_t window_id) override;
   bool IsVisible(uint32_t window_id) override;
   void Show(uint32_t window_id) override;
   void Hide(uint32_t window_id) override;
@@ -162,6 +167,14 @@ class WKWebViewBackend : public LaufeyBackend {
   void RemoveWindowState(uint32_t window_id);
   void InstallGlobalMonitors();
   void RemoveGlobalMonitors();
+  // Install / remove the other-app (forwarding) monitors depending on
+  // whether any window currently wants click-passthrough forwarding.
+  // Main thread only.
+  void UpdateForwardMonitors();
+  // Frontmost visible window with passthrough + forwarding active whose
+  // frame contains `screen_point`, or 0. Fills `out_win` on a hit.
+  // Main thread only.
+  uint32_t ForwardTargetAt(NSPoint screen_point, NSWindow** out_win);
 
   std::map<uint32_t, MacWindowState> windows_;
   std::mutex windows_mutex_;
@@ -172,6 +185,14 @@ class WKWebViewBackend : public LaufeyBackend {
   id mouse_move_monitor_ = nil;
   id scroll_monitor_ = nil;
   bool monitors_installed_ = false;
+
+  // Forwarding monitors: NSEvent *global* monitors that observe mouse events
+  // delivered to OTHER applications — which is what a passthrough window's
+  // events become. Installed only while at least one window has forwarding
+  // enabled, removed when the last one turns it off.
+  id forward_mouse_monitor_ = nil;
+  id forward_mouse_move_monitor_ = nil;
+  id forward_scroll_monitor_ = nil;
 };
 
 // NSWindow → laufey_id mapping for event routing
@@ -852,6 +873,18 @@ void WKWebViewBackend::RemoveGlobalMonitors() {
       [NSEvent removeMonitor:scroll_monitor_];
       scroll_monitor_ = nil;
     }
+    if (forward_mouse_monitor_) {
+      [NSEvent removeMonitor:forward_mouse_monitor_];
+      forward_mouse_monitor_ = nil;
+    }
+    if (forward_mouse_move_monitor_) {
+      [NSEvent removeMonitor:forward_mouse_move_monitor_];
+      forward_mouse_move_monitor_ = nil;
+    }
+    if (forward_scroll_monitor_) {
+      [NSEvent removeMonitor:forward_scroll_monitor_];
+      forward_scroll_monitor_ = nil;
+    }
   }
 }
 
@@ -1530,6 +1563,223 @@ bool WKWebViewBackend::IsClickPassthrough(uint32_t window_id) {
     }
   });
   return result;
+}
+
+void WKWebViewBackend::SetClickPassthroughForward(uint32_t window_id,
+                                                  bool forward) {
+  dispatch_async(dispatch_get_main_queue(), ^{
+    @autoreleasepool {
+      {
+        std::lock_guard<std::mutex> lock(windows_mutex_);
+        auto* state = GetWindow(window_id);
+        if (!state)
+          return;
+        state->click_passthrough_forward = forward;
+      }
+      UpdateForwardMonitors();
+    }
+  });
+}
+
+bool WKWebViewBackend::IsClickPassthroughForward(uint32_t window_id) {
+  __block bool result = false;
+  dispatch_sync(dispatch_get_main_queue(), ^{
+    std::lock_guard<std::mutex> lock(windows_mutex_);
+    auto* state = GetWindow(window_id);
+    if (state) {
+      result = state->click_passthrough_forward;
+    }
+  });
+  return result;
+}
+
+uint32_t WKWebViewBackend::ForwardTargetAt(NSPoint screen_point,
+                                           NSWindow** out_win) {
+  std::lock_guard<std::mutex> lock(windows_mutex_);
+  // orderedWindows is front-to-back, so overlapping forwarding windows
+  // resolve to the one visually on top.
+  for (NSWindow* win in [NSApp orderedWindows]) {
+    uint32_t wid = LaufeyIdForNSWindow(win);
+    if (wid == 0)
+      continue;
+    auto it = windows_.find(wid);
+    if (it == windows_.end())
+      continue;
+    // Forwarding only reports events the OS routed elsewhere *because of
+    // passthrough*; without ignoresMouseEvents an event over this frame that
+    // reached another app was simply over an occluding window.
+    if (!it->second.click_passthrough_forward || ![win ignoresMouseEvents] ||
+        ![win isVisible])
+      continue;
+    if (!NSPointInRect(screen_point, [win frame]))
+      continue;
+    if (out_win)
+      *out_win = win;
+    return wid;
+  }
+  return 0;
+}
+
+void WKWebViewBackend::UpdateForwardMonitors() {
+  bool any_forwarding = false;
+  {
+    std::lock_guard<std::mutex> lock(windows_mutex_);
+    for (auto& [id, state] : windows_) {
+      if (state.click_passthrough_forward) {
+        any_forwarding = true;
+        break;
+      }
+    }
+  }
+
+  if (!any_forwarding) {
+    if (forward_mouse_monitor_) {
+      [NSEvent removeMonitor:forward_mouse_monitor_];
+      forward_mouse_monitor_ = nil;
+    }
+    if (forward_mouse_move_monitor_) {
+      [NSEvent removeMonitor:forward_mouse_move_monitor_];
+      forward_mouse_move_monitor_ = nil;
+    }
+    if (forward_scroll_monitor_) {
+      [NSEvent removeMonitor:forward_scroll_monitor_];
+      forward_scroll_monitor_ = nil;
+    }
+    return;
+  }
+  if (forward_mouse_monitor_)
+    return;
+
+  // Global monitors observe events delivered to OTHER applications — exactly
+  // what a passthrough window's events become. (They never fire for events
+  // this app receives itself, so there is no double dispatch with the local
+  // monitors above.) A global monitor event carries no NSWindow, so
+  // locationInWindow is already in screen coordinates.
+  forward_mouse_monitor_ = [NSEvent
+      addGlobalMonitorForEventsMatchingMask:(NSEventMaskLeftMouseDown |
+                                             NSEventMaskLeftMouseUp |
+                                             NSEventMaskRightMouseDown |
+                                             NSEventMaskRightMouseUp |
+                                             NSEventMaskOtherMouseDown |
+                                             NSEventMaskOtherMouseUp)
+                                    handler:^(NSEvent* event) {
+                                      NSPoint screen_point =
+                                          [event window]
+                                              ? [[event window]
+                                                    convertPointToScreen:
+                                                        [event
+                                                            locationInWindow]]
+                                              : [event locationInWindow];
+                                      NSWindow* win = nil;
+                                      uint32_t wid =
+                                          ForwardTargetAt(screen_point, &win);
+                                      if (wid == 0)
+                                        return;
+
+                                      int state;
+                                      switch ([event type]) {
+                                        case NSEventTypeLeftMouseDown:
+                                        case NSEventTypeRightMouseDown:
+                                        case NSEventTypeOtherMouseDown:
+                                          state = LAUFEY_MOUSE_PRESSED;
+                                          break;
+                                        default:
+                                          state = LAUFEY_MOUSE_RELEASED;
+                                          break;
+                                      }
+                                      int button = NSButtonToLaufey(
+                                          [event buttonNumber]);
+                                      uint32_t modifiers =
+                                          NSModifierFlagsToLaufey(
+                                              [event modifierFlags]);
+                                      int32_t click_count =
+                                          (int32_t)[event clickCount];
+
+                                      NSPoint local = [win
+                                          convertPointFromScreen:screen_point];
+                                      double x = local.x;
+                                      double y =
+                                          [win contentLayoutRect].size.height -
+                                          local.y;
+
+                                      RuntimeLoader::GetInstance()
+                                          ->DispatchMouseClickEvent(
+                                              wid, state, button, x, y,
+                                              modifiers, click_count);
+                                    }];
+
+  forward_mouse_move_monitor_ = [NSEvent
+      addGlobalMonitorForEventsMatchingMask:(NSEventMaskMouseMoved |
+                                             NSEventMaskLeftMouseDragged |
+                                             NSEventMaskRightMouseDragged |
+                                             NSEventMaskOtherMouseDragged)
+                                    handler:^(NSEvent* event) {
+                                      NSPoint screen_point =
+                                          [event window]
+                                              ? [[event window]
+                                                    convertPointToScreen:
+                                                        [event
+                                                            locationInWindow]]
+                                              : [event locationInWindow];
+                                      NSWindow* win = nil;
+                                      uint32_t wid =
+                                          ForwardTargetAt(screen_point, &win);
+                                      if (wid == 0)
+                                        return;
+
+                                      uint32_t modifiers =
+                                          NSModifierFlagsToLaufey(
+                                              [event modifierFlags]);
+                                      NSPoint local = [win
+                                          convertPointFromScreen:screen_point];
+                                      double x = local.x;
+                                      double y =
+                                          [win contentLayoutRect].size.height -
+                                          local.y;
+
+                                      RuntimeLoader::GetInstance()
+                                          ->DispatchMouseMoveEvent(wid, x, y,
+                                                                   modifiers);
+                                    }];
+
+  forward_scroll_monitor_ = [NSEvent
+      addGlobalMonitorForEventsMatchingMask:NSEventMaskScrollWheel
+                                    handler:^(NSEvent* event) {
+                                      NSPoint screen_point =
+                                          [event window]
+                                              ? [[event window]
+                                                    convertPointToScreen:
+                                                        [event
+                                                            locationInWindow]]
+                                              : [event locationInWindow];
+                                      NSWindow* win = nil;
+                                      uint32_t wid =
+                                          ForwardTargetAt(screen_point, &win);
+                                      if (wid == 0)
+                                        return;
+
+                                      double delta_x = [event scrollingDeltaX];
+                                      double delta_y = [event scrollingDeltaY];
+                                      uint32_t modifiers =
+                                          NSModifierFlagsToLaufey(
+                                              [event modifierFlags]);
+                                      int32_t delta_mode =
+                                          [event hasPreciseScrollingDeltas]
+                                              ? LAUFEY_WHEEL_DELTA_PIXEL
+                                              : LAUFEY_WHEEL_DELTA_LINE;
+
+                                      NSPoint local = [win
+                                          convertPointFromScreen:screen_point];
+                                      double x = local.x;
+                                      double y =
+                                          [win contentLayoutRect].size.height -
+                                          local.y;
+
+                                      RuntimeLoader::GetInstance()
+                                          ->DispatchWheelEvent(
+                                              wid, delta_x, delta_y, x, y,
+                                              modifiers, delta_mode);
+                                    }];
 }
 
 bool WKWebViewBackend::IsVisible(uint32_t window_id) {


### PR DESCRIPTION
Stacked on #69 (base branch is `click-passthrough`; retarget to `main` once that merges).

Adds a `set_click_passthrough_forward` / `is_click_passthrough_forward` pair to the backend C ABI (**API version 33 → 34**) — the counterpart of Electron's `setIgnoreMouseEvents(true, { forward: true })`. While a window is passthrough, forwarding keeps its mouse events (moves, clicks, wheel) flowing to the embedder's registered `on_mouse_move` / `on_mouse_click` / `on_wheel` handlers, even though the OS delivers every event to whatever is beneath the window.

**Observation only, by design**: hit-testing is decided by the OS before any handler runs, so a forwarded event cannot be consumed. The intended use is the standard interactive-overlay pattern — watch forwarded mouse moves and toggle `set_click_passthrough(false)` just-in-time when the cursor enters an interactive region, re-enable on leave.

```rust
let overlay = Window::new_with_options(400, 300,
  WindowOptions { frameless: true, transparent: true, ..Default::default() })
  .always_on_top(true)
  .click_passthrough(true)
  .click_passthrough_forward(true)
  .on_mouse_move(|ev| { /* toggle passthrough off over interactive regions */ })
  .load("overlay.html");
```

## Implementation (v1: macOS, WebView + CEF backends)

A passthrough window's events are delivered to *other* applications, which is exactly what `NSEvent` **global** monitors observe — so both backends install global monitors for click/move/wheel masks, lazily when the first window enables forwarding and removed when the last one disables it. The handler hit-tests `[NSApp orderedWindows]` front-to-back for a visible window with passthrough **and** forwarding active whose frame contains the screen point, converts to window-local coordinates (`convertPointFromScreen:` + the same `contentLayoutRect` y-flip the local monitors use), and re-dispatches through the existing `DispatchMouseClick/Move/Wheel` paths. Notes:

- Mouse observation via global monitors needs **no macOS permission** (unlike keyboard).
- Global monitors never fire for the app's own events, so there is no double dispatch with the existing local monitors. The flip side (documented): if an event lands on another *non-passthrough window of the same app* overlapping the overlay, the overlay's handlers don't fire for it.
- Forwarding without passthrough is deliberately inert — normal per-window delivery already fires the handlers, and dispatching global events for a window that isn't passthrough would report events that actually hit an occluding window.

**Not implemented yet** (flag ignored, getter reports `false`): Windows (`WH_MOUSE_LL` hook), Linux/X11 (XInput2 raw events — the CEF backend already has that monitor connection to build on), winit. Linux/Wayland cannot support it (no global input observation). All documented in `docs/window-management.md`.

## Testing

- `cargo test -p laufey`: 45 tests pass; webview + CEF backends build cleanly.
- New capability-probed `set_click_passthrough_forward round-trips` in the `native_e2e` battery: **PASS** under WebView and CEF on macOS (overall PASS), **N/A** under winit as expected.
- What is machine-verified is the flag round-trip, monitor install/remove, and builds; *actual* event forwarding needs real OS input (synthetic `CGEventPost` requires an Accessibility grant), so that part needs a quick manual check: run an overlay with forwarding on, hover it, and confirm `on_mouse_move` fires while clicks land in the window beneath.