### PR TITLE
fix(cef/macos): route Cmd+Q to menu key equivalents and the keyboard pipeline

### DIFF
--- a/cef/src/main_mac.mm
+++ b/cef/src/main_mac.mm
@@ -40,12 +40,38 @@ void LaufeyOpenExternalURL(const std::string& url) {
 }
 
 - (void)sendEvent:(NSEvent*)event {
-  // Swallow Cmd+Q so Chromium's "Hold ⌘Q to Quit" panel never fires and no
-  // default termination happens. Embedders receive the key event through the
-  // normal keyboard pipeline and decide what (if anything) to do.
+  // Cmd+Q must not reach Chromium's dispatch: it would show the "Hold ⌘Q to
+  // Quit" panel and run a default termination. But the keystroke still has to
+  // be observable by the embedder, and both observation paths hang off this
+  // dispatch: menu key equivalents are matched from sendEvent:, and the
+  // keyboard pipeline (OnKeyEvent) is fed by CEF from the browser view the
+  // event would have reached. So instead of dropping the event, first let the
+  // main menu match it — a "quit" role item or a custom Cmd+Q accelerator
+  // fires exactly as if clicked — and otherwise forward it straight to the
+  // embedder's keyboard handler before swallowing it.
   if (event.type == NSEventTypeKeyDown &&
       (event.modifierFlags & NSEventModifierFlagCommand) &&
       [event.charactersIgnoringModifiers isEqualToString:@"q"]) {
+    CefScopedSendingEvent sendingEventScoper;
+    if ([[NSApp mainMenu] performKeyEquivalent:event]) {
+      return;
+    }
+    uint32_t wid = RuntimeLoader::GetInstance()->GetLaufeyIdForNSWindow(
+        (__bridge void*)event.window);
+    if (wid != 0) {
+      uint32_t modifiers = LAUFEY_MOD_META;
+      if (event.modifierFlags & NSEventModifierFlagShift)
+        modifiers |= LAUFEY_MOD_SHIFT;
+      if (event.modifierFlags & NSEventModifierFlagControl)
+        modifiers |= LAUFEY_MOD_CONTROL;
+      if (event.modifierFlags & NSEventModifierFlagOption)
+        modifiers |= LAUFEY_MOD_ALT;
+      std::string key = laufey_common::NSEventKeyToKey((__bridge void*)event);
+      std::string code = laufey_common::NSEventKeyToCode(event.keyCode);
+      RuntimeLoader::GetInstance()->DispatchKeyboardEvent(
+          wid, LAUFEY_KEY_PRESSED, key.c_str(), code.c_str(), modifiers,
+          event.isARepeat);
+    }
     return;
   }
   CefScopedSendingEvent sendingEventScoper;


### PR DESCRIPTION
Fixes #50.

## Problem

`LaufeyApplication sendEvent:` dropped the Cmd+Q `NSEvent` entirely to suppress Chromium's "Hold ⌘Q to Quit" panel. But both ways an embedder could observe the key hang off that same dispatch: menu key equivalents are matched from `sendEvent:`, and the keyboard pipeline (`OnKeyEvent` → `on_keyboard_event`) is fed by CEF from the browser view the event never reached. So Cmd+Q was observable nowhere — a quit-role or custom Cmd+Q accelerator never fired from the keyboard (clicking worked), and the keyboard handler never saw the key.

## Fix

Instead of dropping the event, `sendEvent:` now:

1. gives `[[NSApp mainMenu] performKeyEquivalent:event]` a chance first — a `quit`-role item or a custom Cmd+Q accelerator fires exactly as if clicked;
2. if no menu item claims it, forwards the event straight to the embedder's keyboard handler via `RuntimeLoader::DispatchKeyboardEvent` (window id resolved through the existing NSWindow → laufey-id mapping, key/code via the shared `laufey_common::NSEventKeyToKey/NSEventKeyToCode` helpers);
3. only then swallows it, so Chromium's default quit handling still never runs.

Cmd+Q key-up still flows through the normal `OnKeyEvent` path as before, so embedders see a consistent release event.

## Verification

OS-level key injection is TCC-gated, so I verified with a test runtime dylib that synthesizes the Cmd+Q `NSEvent` **in-process** and pushes it through `[NSApp sendEvent:]` on the main thread — exercising the exact override:

- **No menu:** handler received `KeyboardEvent { state: Pressed, key: "q", code: "KeyQ", modifiers: { meta: true } }`, app stayed alive.
- **Custom item with `CmdOrCtrl+Q` accelerator:** menu click handler fired, no quit, no spurious key event.
- **`quit` role item:** app terminated cleanly through the existing `terminate:` → `CloseAllBrowsers(true)` path.