### PR TITLE
fix(cef/windows): embed Windows application manifest so GPU acceleration works

### DIFF
--- a/cef/CMakeLists.txt
+++ b/cef/CMakeLists.txt
@@ -198,6 +198,17 @@ elseif(OS_WINDOWS)
 
   add_executable(${CEF_TARGET} WIN32 ${LAUFEY_SRCS_COMMON} ${LAUFEY_SRCS_WIN})
   SET_EXECUTABLE_TARGET_PROPERTIES(${CEF_TARGET})
+
+  # Embed the application manifest (win/laufey.exe.manifest merged with
+  # win/compatibility.manifest, same layout as cefclient). CEF's toolchain
+  # links with /MANIFEST:NO, so without this post-build mt.exe step the exe
+  # ships with no manifest at all. The Win10 supportedOS GUID in the
+  # compatibility section is load-bearing: GetVersionEx caps the reported OS
+  # version at Windows 8 for unmanifested exes, and Chromium then treats the
+  # OS as unsupported and disables all GPU acceleration (WebGL included) —
+  # see denoland/deno#36523.
+  ADD_WINDOWS_MANIFEST("${CMAKE_CURRENT_SOURCE_DIR}/win" "${CEF_TARGET}" "exe")
+
   target_link_libraries(${CEF_TARGET} libcef_dll_wrapper ${CEF_LIB_RELEASE} ${CEF_STANDARD_LIBS} laufey_backend_common)
   target_include_directories(${CEF_TARGET} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src" "${LAUFEY_INCLUDE_DIR}")
 

--- a/cef/win/compatibility.manifest
+++ b/cef/win/compatibility.manifest
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!--The ID below indicates application support for Windows Vista -->
+      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+      <!--The ID below indicates application support for Windows 7 -->
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+      <!--The ID below indicates application support for Windows 8 -->
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+      <!--The ID below indicates application support for Windows 8.1 -->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <!--The ID below indicates application support for Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+      <!-- This tag is required for XAML islands usage in the process for media scenarios. -->
+      <!-- This version corresponds to the Windows 10 May 2019 Update. -->
+      <maxversiontested Id="10.0.18362.0"/>
+    </application>
+  </compatibility>
+</assembly>

--- a/cef/win/laufey.exe.manifest
+++ b/cef/win/laufey.exe.manifest
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+
+  <!--The compatibility section will be merged from compatibility.manifest -->
+
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity type="Win32" name="Microsoft.Windows.Common-Controls" version="6.0.0.0" processorArchitecture="*" publicKeyToken="6595b64144ccf1df" language="*"></assemblyIdentity>
+    </dependentAssembly>
+  </dependency>
+
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+</assembly>


### PR DESCRIPTION
Fixes denoland/deno#36523 (Deno desktop on Windows has no hardware acceleration; also the root cause behind the chrome://gpu screenshot in denoland/deno#36031).

## Root cause

CEF's toolchain links executables with `/MANIFEST:NO` (`cef_variables.cmake:516`, annotated "see ADD_WINDOWS_MANIFEST macro usage") and expects the client to embed its own manifest post-build, the way cefclient does. laufey's Windows branch never calls `ADD_WINDOWS_MANIFEST`, so the shipped `laufey.exe` contains **no embedded manifest at all** (verified against the `laufey-cef-x86_64-pc-windows-msvc.zip` v0.6.1 release binary — meanwhile `bootstrap.exe` from the same CEF distribution carries the full compatibility manifest).

Chromium detects the Windows version with `GetVersionEx`, which is manifest-gated: without the Win10 `supportedOS` GUID (`{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}`), the OS reports itself as Windows 8 (6.2). Chromium 149 dropped pre-Win10 support, so it treats the OS as unsupported and disables the entire GPU stack — `chrome://gpu` shows every feature "Software only"/"Disabled", GPU info is never collected (`VENDOR = 0xffff`), and WebGL fails outright with `GL_VENDOR = Disabled ... BindToCurrentSequence failed` on any hardware, including the reporter's up-to-date RTX 5070.

Same failure mode + cure previously seen in CefSharp for self-hosted subprocess exes: cefsharp/CefSharp#4707.

## Fix

- `cef/win/laufey.exe.manifest` — common-controls dependency + `asInvoker`, mirroring `cefclient.exe.manifest`.
- `cef/win/compatibility.manifest` — verbatim Chromium `build/win/compatibility.manifest` (the same content CEF embeds in `bootstrap.exe`).
- `cef/CMakeLists.txt` — call `ADD_WINDOWS_MANIFEST` on the Windows target; the macro runs `mt.exe` post-build to merge and embed both files (available in the vcvarsall environment `build_win.bat` sets up).

## Verification

I could verify the missing-manifest state of the release binaries and the toolchain behavior, but not run the fixed build (no Windows machine here — and CI doesn't build the CEF backend on Windows). To confirm on a Windows box: build via `build_win.bat`, run, and check `chrome://gpu` flips from all-"Software only" to hardware-accelerated; a Three.js page should get a WebGL context.

Notes:
- `laufey_webview.exe` also ships without a manifest, but WebView2 renders in Microsoft's own (manifested) runtime processes, so it doesn't exhibit this bug; can add the same treatment there as a follow-up if wanted.
- After a release, denoland/deno needs a version pin + `laufey_sums.lock` bump to pick this up.