### PR TITLE
feat(menu): take menu item icons as PNG bytes instead of a file path

### DIFF
--- a/backend-common/src/menu_mac.mm
+++ b/backend-common/src/menu_mac.mm
@@ -239,21 +239,26 @@ NSMenu* BuildNSMenuFromValue(laufey_value_t* val, const laufey_backend_api_t* ap
       [nsItem setToolTip:[NSString stringWithUTF8String:tooltipStr.c_str()]];
     }
 
-    // icon -> NSMenuItem.image, loaded from a file path. Marked as a template
+    // icon -> NSMenuItem.image, decoded from PNG bytes. Marked as a template
     // image so a monochrome (black + alpha) icon tints correctly: black in the
     // normal state, white when the item is highlighted/selected. (A full-color
     // icon is flattened to its alpha mask under this default, matching the
     // tray-icon behavior.)
-    std::string iconStr = DictString(api, itemVal, "icon");
-    if (!iconStr.empty()) {
-      NSImage* iconImg = [[NSImage alloc]
-          initWithContentsOfFile:[NSString stringWithUTF8String:iconStr.c_str()]];
-      if (iconImg) {
-        [iconImg setSize:NSMakeSize(16, 16)];
-        [iconImg setTemplate:YES];
-        [nsItem setImage:iconImg];
+    laufey_value_t* iconVal = api->value_dict_get(itemVal, "icon");
+    if (iconVal && api->value_is_binary(iconVal)) {
+      size_t iconLen = 0;
+      const void* iconBytes = api->value_get_binary(iconVal, &iconLen);
+      if (iconBytes && iconLen > 0) {
+        NSData* iconData = [NSData dataWithBytes:iconBytes length:iconLen];
+        NSImage* iconImg = [[NSImage alloc] initWithData:iconData];
+        if (iconImg) {
+          [iconImg setSize:NSMakeSize(16, 16)];
+          [iconImg setTemplate:YES];
+          [nsItem setImage:iconImg];
+        }
       }
     }
+    if (iconVal) api->value_free(iconVal);
 
     [menu addItem:nsItem];
   }

--- a/capi/include/laufey.h
+++ b/capi/include/laufey.h
@@ -479,10 +479,10 @@ struct laufey_backend_api {
 
   // Application menu. menu_template is a laufey_value_t list of menu items.
   // Each item is a dict with: label, submenu (list), role, type, id,
-  // accelerator. When a custom item (with "id") is clicked, on_click is called
-  // with the id. On macOS the menu is applied to the global menu bar and
-  // swapped on window focus. On Windows/Linux the menu is attached to the
-  // specific window.
+  // accelerator, checked (bool), icon (binary, PNG bytes), tooltip. When a
+  // custom item (with "id") is clicked, on_click is called with the id. On
+  // macOS the menu is applied to the global menu bar and swapped on window
+  // focus. On Windows/Linux the menu is attached to the specific window.
   void (*set_application_menu)(void* backend_data, uint32_t window_id,
                                laufey_value_t* menu_template,
                                laufey_menu_click_fn on_click,

--- a/capi/include/win32_menu.h
+++ b/capi/include/win32_menu.h
@@ -123,20 +123,14 @@ inline void FreeVal(const laufey_backend_api_t* api, laufey_value_t* v) {
     api->value_free(v);
 }
 
-// Decode a PNG file into a 32bpp premultiplied-alpha top-down DIB section
+// Decode PNG bytes into a 32bpp premultiplied-alpha top-down DIB section
 // suitable for a menu item bitmap (hbmpItem). Scaled to the small-icon metric
 // so it lines up with the menu gutter. Returns nullptr on any failure; the
 // caller owns the returned HBITMAP and must DeleteObject it. Unlike macOS,
 // the image is rendered as-is — there is no template tinting on selection.
-inline HBITMAP LoadMenuIconBitmap(const std::string& path) {
-  if (path.empty())
+inline HBITMAP LoadMenuIconBitmap(const void* bytes, size_t len) {
+  if (!bytes || len == 0)
     return nullptr;
-
-  int wlen = MultiByteToWideChar(CP_UTF8, 0, path.c_str(), -1, nullptr, 0);
-  if (wlen <= 0)
-    return nullptr;
-  std::wstring wpath(static_cast<size_t>(wlen - 1), L'\0');
-  MultiByteToWideChar(CP_UTF8, 0, path.c_str(), -1, &wpath[0], wlen);
 
   CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
   IWICImagingFactory* factory = nullptr;
@@ -145,9 +139,14 @@ inline HBITMAP LoadMenuIconBitmap(const std::string& path) {
     return nullptr;
   }
 
+  IWICStream* stream = nullptr;
   IWICBitmapDecoder* decoder = nullptr;
-  factory->CreateDecoderFromFilename(wpath.c_str(), nullptr, GENERIC_READ,
+  if (SUCCEEDED(factory->CreateStream(&stream)) && stream &&
+      SUCCEEDED(stream->InitializeFromMemory((BYTE*)const_cast<void*>(bytes),
+                                             (DWORD)len))) {
+    factory->CreateDecoderFromStream(stream, nullptr,
                                      WICDecodeMetadataCacheOnLoad, &decoder);
+  }
   IWICBitmapFrameDecode* frame = nullptr;
   if (decoder)
     decoder->GetFrame(0, &frame);
@@ -201,6 +200,8 @@ inline HBITMAP LoadMenuIconBitmap(const std::string& path) {
     frame->Release();
   if (decoder)
     decoder->Release();
+  if (stream)
+    stream->Release();
   factory->Release();
   return hbmp;
 }
@@ -327,24 +328,24 @@ inline HMENU BuildMenuFromValue(laufey_value_t* val,
     }
     FreeVal(api, checkedVal);
 
-    // icon -> menu item bitmap (a PNG file path), loaded below after the item
+    // icon -> menu item bitmap (PNG bytes), decoded below after the item
     // exists so it can be attached by command id.
-    std::string iconPath;
+    std::vector<uint8_t> iconPng;
     laufey_value_t* iconVal = api->value_dict_get(itemVal, "icon");
-    if (iconVal && api->value_is_string(iconVal)) {
+    if (iconVal && api->value_is_binary(iconVal)) {
       size_t iconLen = 0;
-      char* iconStr = api->value_get_string(iconVal, &iconLen);
-      if (iconStr) {
-        iconPath = iconStr;
-        api->value_free_string(iconStr);
+      const void* iconBytes = api->value_get_binary(iconVal, &iconLen);
+      if (iconBytes && iconLen > 0) {
+        const uint8_t* p = static_cast<const uint8_t*>(iconBytes);
+        iconPng.assign(p, p + iconLen);
       }
     }
     FreeVal(api, iconVal);
 
     AppendMenuA(menu, flags, cmdId, label.c_str());
 
-    if (!iconPath.empty()) {
-      HBITMAP hbmp = LoadMenuIconBitmap(iconPath);
+    if (!iconPng.empty()) {
+      HBITMAP hbmp = LoadMenuIconBitmap(iconPng.data(), iconPng.size());
       if (hbmp) {
         MENUITEMINFOA mii = {};
         mii.cbSize = sizeof(mii);

--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -1664,11 +1664,12 @@ pub enum MenuItem {
     /// Checkmark next to the item (`NSMenuItem.state` / `MFS_CHECKED` /
     /// `GtkCheckMenuItem`). All platforms.
     checked: bool,
-    /// Item icon: a file path to a PNG image. macOS and Windows (Linux
-    /// unsupported — GtkMenuItem has no image slot). On macOS a monochrome
-    /// black+alpha PNG is rendered as a template so it tints to white on
-    /// selection; Windows renders the image as-is.
-    icon: Option<String>,
+    /// Item icon: PNG-encoded image bytes, matching the tray and
+    /// notification icon APIs. macOS and Windows (Linux unsupported —
+    /// GtkMenuItem has no image slot). On macOS a monochrome black+alpha
+    /// PNG is rendered as a template so it tints to white on selection;
+    /// Windows renders the image as-is.
+    icon: Option<Vec<u8>>,
     /// Tooltip shown on hover. macOS only (matches Electron's `toolTip`).
     tooltip: Option<String>,
   },
@@ -1707,7 +1708,7 @@ impl MenuItem {
           dict.insert("checked".to_string(), Value::Bool(true));
         }
         if let Some(icon) = icon {
-          dict.insert("icon".to_string(), Value::String(icon.clone()));
+          dict.insert("icon".to_string(), Value::Binary(icon.clone()));
         }
         if let Some(tooltip) = tooltip {
           dict.insert("tooltip".to_string(), Value::String(tooltip.clone()));
@@ -2862,7 +2863,7 @@ mod tests {
       accelerator: Some("CmdOrCtrl+O".into()),
       enabled: false,
       checked: true,
-      icon: Some("doc".into()),
+      icon: Some(vec![0x89, b'P', b'N', b'G']),
       tooltip: Some("Open a file".into()),
     };
     let v = item.to_value();
@@ -2885,10 +2886,12 @@ mod tests {
       dict_get(&v, "checked").and_then(|v| v.as_bool()),
       Some(true)
     );
-    assert_eq!(
-      dict_get(&v, "icon").and_then(|v| v.as_string()),
-      Some("doc")
-    );
+    // Icon comes through as binary PNG bytes, matching the tray and
+    // notification icon wire format.
+    match dict_get(&v, "icon") {
+      Some(Value::Binary(b)) => assert_eq!(b, &vec![0x89, b'P', b'N', b'G']),
+      _ => panic!("icon must be Value::Binary"),
+    }
     assert_eq!(
       dict_get(&v, "tooltip").and_then(|v| v.as_string()),
       Some("Open a file")

--- a/docs/menus.md
+++ b/docs/menus.md
@@ -8,10 +8,11 @@ When the user clicks an item that has an identifier, your callback is invoked
 with that identifier.
 
 Regular items also support a few visual properties, mirroring Electron's
-`MenuItem`: `checked` (a checkmark, all platforms), `icon` (a file path to a PNG
-image — macOS and Windows, unsupported on Linux; on macOS a monochrome
-black+alpha PNG is treated as a template and tints to white on selection, while
-Windows renders it as-is), and `tooltip` (hover text — macOS only).
+`MenuItem`: `checked` (a checkmark, all platforms), `icon` (PNG-encoded image
+bytes, matching the tray and notification icon APIs — macOS and Windows,
+unsupported on Linux; on macOS a monochrome black+alpha PNG is treated as a
+template and tints to white on selection, while Windows renders it as-is), and
+`tooltip` (hover text — macOS only).
 
 ```rust
 use laufey::MenuItem;
@@ -25,7 +26,7 @@ let menu = [MenuItem::Submenu {
       accelerator: Some("CmdOrCtrl+O".into()),
       enabled: true,
       checked: false,
-      icon: Some("icons/open.png".into()), // file path to a template PNG
+      icon: Some(include_bytes!("icons/open.png").to_vec()), // PNG bytes
       tooltip: Some("Open a file".into()),
     },
     MenuItem::Separator,

--- a/examples/hello/src/lib.rs
+++ b/examples/hello/src/lib.rs
@@ -217,7 +217,7 @@ fn hello_main() {
             accelerator: None,
             enabled: true,
             checked: false,
-            icon: Some("examples/hello/icons/bell.png".into()),
+            icon: Some(include_bytes!("../icons/bell.png").to_vec()),
             tooltip: Some("Play a sound".into()),
           },
         ],


### PR DESCRIPTION
The tray and notification icon APIs already take PNG-encoded bytes; menu item icons were the one image surface that required a file on disk. That's awkward for embedders whose icons are bundled assets (e.g. `deno compile`'d desktop apps), which would otherwise have to write temp files and manage their lifetime around the backends' async menu builds (macOS builds the NSMenu in a `dispatch_async` block, so the file can't be deleted right after the FFI call returns).

Changes:
- `MenuItem::Item.icon` is now `Option<Vec<u8>>` (PNG bytes); the menu dict's `"icon"` entry is a binary value rather than a string path.
- macOS (`menu_mac.mm`): decodes via `NSImage initWithData:`, still template-rendered at 16×16; the fetched `icon` value is now also freed (`value_dict_get` returns an owned wrapper).
- Windows (`win32_menu.h`): `LoadMenuIconBitmap` decodes through a WIC memory stream (`InitializeFromMemory` + `CreateDecoderFromStream`), mirroring the tray/notification decoders; the rest of the DIB pipeline is unchanged.
- Docs (`docs/menus.md`, `laufey.h`) and the hello example (`include_bytes!`) updated.

Compat: a backend receiving the old string form (or an old backend receiving binary) ignores the icon rather than erroring, since both sides type-check the value before using it.

Breaking change to the `laufey` crate's Rust API (field type), so this wants a 0.7.0 release.

Downstream: denoland/deno#36649 exposes these menu item fields through `Deno.desktop` and will switch to `Uint8Array` icons on top of this.

Note: `make lint` currently fails on macOS with a pre-existing `unused_mut` in `backend-winit-common` (`store_window_handles`'s `display_ptr` is only assigned under X11/Wayland cfg branches); unrelated to this PR. `cargo test -p laufey`, `cargo clippy -p laufey`, `make webview`, and `make fmt-check` all pass.