### PR TITLE
chore: release 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1877,7 +1877,7 @@ dependencies = [
 
 [[package]]
 name = "laufey"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "bindgen",
  "tokio",

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "laufey"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 description = "A web embedded framework: build cross-platform apps with web technologies and your choice of browser engine."
 license = "MIT"


### PR DESCRIPTION
Bumps the `laufey` crate to 0.7.0.

Since 0.6.1: menu item icons as PNG bytes (#75, breaking — `MenuItem::Item.icon` is now `Option<Vec<u8>>`), click passthrough forwarding (#69, #70), print_to_pdf (#49), Linux appindicator dlopen fix (#73), macOS Cmd+Q routing (#72), Windows GPU manifest (#74). `LAUFEY_API_VERSION` is now 34 (was 30 in the 0.6.1 release).

After landing, tag to publish: `git tag v0.7.0 && git push origin v0.7.0` — the tag triggers the crates.io publish workflow and the CI release job that uploads the prebuilt backend archives.

Unblocks denoland/deno#36649.